### PR TITLE
Allow ASSET_DIR and RESOURCE_INIT_DIR to be set at build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,14 @@ VERSION     := 2.1.1
 
 # Where does this get installed
 PREFIX      := /usr/local
-ASSET_DIR   := $(PREFIX)/share/$(PACKAGE)
+
+# Where assets (font file, etc) are read from
+# (You can build a version that loads assets from the source tree with: ASSET_DIR=`pwd`/res make )
+ASSET_DIR   ?= $(PREFIX)/share/$(PACKAGE)
+
+# Where default versions of resource files (linapple.conf, etc) are obtained from initially
+# (You can build a version that copies resources from the source tree with: RESOURCE_INIT_DIR=`pwd`/res make )
+RESOURCE_INIT_DIR ?= /etc/linapple
 
 #Compiler and Linker
 CC          := g++
@@ -42,7 +49,7 @@ CURL_LIBS = $(shell $(CURL_CONFIG) --libs)
 #DEBUGGING
 #CFLAGS      := -Wall -O0 -ggdb -ansi -c -finstrument-functions
 #OPTIMIZED
-CFLAGS      := -Wall -O3 -ansi -c -DASSET_DIR=\"$(ASSET_DIR)\"
+CFLAGS      := -Wall -O3 -ansi -c -DASSET_DIR=\"$(ASSET_DIR)\" -DRESOURCE_INIT_DIR=\"$(RESOURCE_INIT_DIR)\"
 CFLAGS 		+= $(SDL_CFLAGS)
 CFLAGS 		+= $(CURL_CFLAGS)
 

--- a/inc/config.h
+++ b/inc/config.h
@@ -10,7 +10,11 @@
 #define CONF_DIRECTORY_NAME "/conf/"
 #define SAVED_DIRECTORY_NAME "/saved/"
 #define FTP_DIRECTORY_NAME "/ftp/"
-#define INSTALL_DIRECTORY_NAME "/etc/linapple/"
+#ifdef RESOURCE_INIT_DIR
+  #define INSTALL_DIRECTORY_NAME RESOURCE_INIT_DIR "/"
+#else
+  #define INSTALL_DIRECTORY_NAME "/etc/linapple/"
+#endif
 #define MAX_FILENAME_LENGTH 255
 
 class Config

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -45,7 +45,7 @@ SDL_Surface *Asset_LoadBMP(const char *filename)
   SDL_Surface *surf;
   char *path = (char *)SDL_malloc(sizeof(char[PATH_MAX]));
   if (NULL == path) {
-    fprintf(stderr, "Asset_Init: Allocating path: %s\n", SDL_GetError());
+    fprintf(stderr, "Asset_LoadBMP: Allocating path: %s\n", SDL_GetError());
     return NULL;
   }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -36,10 +36,10 @@ void Config::ChangeToHomeDirectory()
 
 void Config::ChangeToUserDirectory()
 {
-	if(chdir((GetHomePath() + USER_DIRECTORY_NAME).c_str()))
+	if(chdir(GetUserFilePath().c_str()))
 	{
 
-    cout << "Cannot switch to home directory ('" << GetHomePath().c_str() << "')" << std::endl;
+    cout << "Cannot switch to user directory ('" << GetUserFilePath().c_str() << "')" << std::endl;
 	}
 }
 


### PR DESCRIPTION
In doing this, I spent a fair amount of time trying to understand `src/config.cpp` and `src/asset.cpp` and their roles in how things work currently.

There is a lot of confusing and fragile stuff in `src/config.cpp` that I'd like to clean up, but my understanding is that it's basically going to go away when the code switches to SDL2, so there's not much point.  If I do decide any of that is worth doing, I'll do it in another branch.

So, this branch contains only* the changes needed to allow building a version that doesn't look at any "system" directories for the files it needs.  To achieve that,

- `RESOURCE_INIT_DIR` is defined as the directory that files are copied from when they're copied into the `$HOME/linapple` directory when it is first made.
- `ASSET_DIR` and `RESOURCE_INIT_DIR` can be set when invoking `make`.

linapple can then be built with

    ASSET_DIR=`pwd`/res RESOURCE_INIT_DIR=`pwd`/res make

to build a version which gets all of its assets and initial resource files from the source tree (e.g. your local clone of the git repo).  This feature is useful during development, and was the primary reason I had a fork of linapple in the first place.

*Not strictly true, as I also fixed two error messages. But that's very very minor.