### PR TITLE
Don't create *.pcm files we literally never write anything to.

### DIFF
--- a/inc/AppleWin.h
+++ b/inc/AppleWin.h
@@ -13,8 +13,6 @@
 
 #include <curl/curl.h>
 
-extern FILE * spMono,*spStereo;
-
 extern char VERSIONSTRING[];  // Contructed in WinMain()
 
 extern TCHAR     *g_pAppTitle;

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -783,8 +783,6 @@ LPSTR GetNextArg(LPSTR lpCmdLine)
 }
 
 
-FILE *spMono, *spStereo;
-
 //---------------------------------------------------------------------------
 
 int main(int argc, char * lpCmdLine[])
@@ -804,8 +802,6 @@ int main(int argc, char * lpCmdLine[])
   bool bBoot = false;
 
   registry = fopen(REGISTRY, "rt");  // open conf file (linapple.conf by default)
-  spMono = fopen("speakersmono.pcm","wb");
-  spStereo = fopen("speakersstereo.pcm","wb");
 
   LPSTR szImageName_drive1 = NULL; // file names for images of drive1 and drive2
   LPSTR szImageName_drive2 = NULL;
@@ -1098,8 +1094,6 @@ int main(int argc, char * lpCmdLine[])
   {
     fclose(registry);    //close conf file (linapple.conf by default)
   }
-  fclose(spMono);
-  fclose(spStereo);
 
   SDL_Quit();
 // CURL routines


### PR DESCRIPTION
Every time after I finish using `linapple`, I see there are these zero-size `pcm` files in my directory.  Looking at the code, it turns out these files are created when `linapple` starts, and then literally never referenced anywhere else in the code!  I imagine the intent was to be able to record the audio from the emulated speaker, but if that feature ever happens, it should definitely be done in a better way than this.  So this change just stops these files from being created.