### PR TITLE
Stylistic cleanups

### DIFF
--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -507,23 +507,23 @@ int DiskInsert (int drive, LPCTSTR imagefilename, BOOL writeprotected, BOOL crea
   int lf = strlen(imagefilename);
   if(lf > 3 && imagefilename[lf-1] == 'z' && imagefilename[lf-2] == 'g' && imagefilename[lf-3] == '.')
   {// .gz?
-  snprintf(tempdsk, 12, "drive%d.dsk", drive);
-        if (DiskUnGzip((char*)imagefilename, tempdsk)) {
-    writeprotected = 1;
-    createifnecessary = 0;
-    tmp = tempdsk;
-  }
+    snprintf(tempdsk, 12, "drive%d.dsk", drive);
+    if (DiskUnGzip((char*)imagefilename, tempdsk)) {
+      writeprotected = 1;
+      createifnecessary = 0;
+      tmp = tempdsk;
+    }
   }
   else
   if(lf > 4 && imagefilename[lf-1] == 'p' && imagefilename[lf-2] == 'i' && imagefilename[lf-3] == 'z'
               && imagefilename[lf-4] == '.') // .zip?
   {
-  snprintf(tempdsk, 12, "drive%d.dsk", drive);
-        if (DiskUnZip((char*)imagefilename, tempdsk)) {
-    writeprotected = 1;
-    createifnecessary = 0;
-    tmp = tempdsk;
-  }
+    snprintf(tempdsk, 12, "drive%d.dsk", drive);
+    if (DiskUnZip((char*)imagefilename, tempdsk)) {
+      writeprotected = 1;
+      createifnecessary = 0;
+      tmp = tempdsk;
+    }
   }
 
   fptr->writeprotected = writeprotected;
@@ -538,6 +538,10 @@ int DiskInsert (int drive, LPCTSTR imagefilename, BOOL writeprotected, BOOL crea
     snprintf(s_title, MAX_DISK_IMAGE_NAME + 32, "%s - %s", g_pAppTitle, tmp); //
     if(drive == 0) SDL_WM_SetCaption(s_title, g_pAppTitle);// change caption just for drive 0 (leading)
     printf("Disk is inserted. Full name = %s\n", /*g_aFloppyDisk[drive].fullname*/imagefilename);
+  }
+  else
+  {
+    printf("Error %d when inserting disk %s\n", error, imagefilename);
   }
   return error;
 }

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -54,10 +54,13 @@ SDL_Surface *Asset_LoadBMP(const char *filename)
   if (NULL == surf) {
     snprintf(path, PATH_MAX, "%s%s", system_exedir, filename);
     surf = SDL_LoadBMP(path);
-    if (NULL == surf) {
-      fprintf(stderr, "Asset_LoadBMP: Couldn't load %s in either %s or %s!\n",
-          filename, system_assets, system_exedir);
-    }
+  }
+
+  if (NULL != surf) {
+    fprintf(stderr, "Asset_LoadBMP: Loaded %s from %s\n", filename, path);
+  } else {
+    fprintf(stderr, "Asset_LoadBMP: Couldn't load %s in either %s or %s!\n",
+        filename, system_assets, system_exedir);
   }
 
   SDL_free(path);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -46,10 +46,12 @@ void Config::ChangeToUserDirectory()
 // Simple POSIX file copy
 bool Config::CopyFile(std::string srcFile, std::string destFile)
 {
-  const int bufSize = 1024;
+	const int bufSize = 1024;
 	bool bRet = true;
 	char buf[bufSize];
 	size_t size;
+
+	std::cout << "Copying '" << srcFile.c_str() << "' to '" << destFile.c_str() << "'" << std::endl;
 
 	// Attempt to open files
 	int source = open(srcFile.c_str(), O_RDONLY, 0);
@@ -61,9 +63,8 @@ bool Config::CopyFile(std::string srcFile, std::string destFile)
 		while ((size = read(source, buf, bufSize)) > 0) {
 			if(0 >= write(dest, buf, size)) {
 				// Handle error;
-        std::cout << "Error writing '" << destFile.c_str() << "' (" << size << ")" << std::endl;
-        std::cout << "Source file: " << srcFile.c_str() << std::endl;
-
+				std::cout << "Error writing '" << destFile.c_str() << "' (" << size << ")" << std::endl;
+				std::cout << "Source file: " << srcFile.c_str() << std::endl;
 				bRet = false;
 				break;
 			}
@@ -77,7 +78,7 @@ bool Config::CopyFile(std::string srcFile, std::string destFile)
 			close(dest);
 		}
 	} else {
-    std::cout << "Error copying '" << srcFile.c_str() << "' to '" << destFile.c_str() << "'" << std::endl;
+		std::cout << "Error copying '" << srcFile.c_str() << "' to '" << destFile.c_str() << "'" << std::endl;
 		bRet = false;
 	}
 	return bRet;


### PR DESCRIPTION
These were in another branch I was working on, but they don't affect behaviour (except to produce slightly better diagnostic messages) so I extracted them to their own branch.

Code that appears after a `{` should be indented to some column that is, y'know, to the right of the code above it.  I feel pretty strongly about that.  I'm less picky about what column exactly, but it's nice when it lines up with the other lines in the indented block.