### PR TITLE
Create userdir as "$HOME/.linapple/" instead of "$HOME/linapple/".

### DIFF
--- a/inc/config.h
+++ b/inc/config.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#define USER_DIRECTORY_NAME "/linapple/"
+#define USER_DIRECTORY_NAME "/.linapple/"
 #define CONF_DIRECTORY_NAME "/conf/"
 #define SAVED_DIRECTORY_NAME "/saved/"
 #define FTP_DIRECTORY_NAME "/ftp/"


### PR DESCRIPTION
If a program creates a file or directory in my home directory without asking me about it first, I strongly prefer that its name starts with a dot.  I suspect I'm not the only Linux user with this preference.