### PR TITLE
Abort if we can't stat a file we're supposed to copy to userdir.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fcntl.h>
 #include <cstdio>
+#include <stdexcept>
 
 #include "config.h"
 
@@ -97,9 +98,7 @@ static const char *files[] =
   "charset40.bmp",
   "font.bmp",
   "splash.bmp",
-  "Printer.txt",
   "Master.dsk",
-  "LICENSE",
   "linapple.conf",
   "icon.bmp",
   ""
@@ -124,18 +123,24 @@ static const char *files[] =
 		mkdir((userDir + CONF_DIRECTORY_NAME).c_str(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 		mkdir((userDir + SAVED_DIRECTORY_NAME).c_str(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 		mkdir((userDir + FTP_DIRECTORY_NAME).c_str(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+        }
 
-    cout << "Copying Files\n" << std::endl;
+        cout << "Copying Files" << std::endl;
+        for( unsigned int i = 0; *files[ i ]; i++ ) {
+            string src = (GetInstallPath() + files[ i ]);
+            string dest = (GetUserFilePath() + files[ i ]);
+            if (stat (dest.c_str(), &buffer) == 0) {
+                // It's already there.
+                continue;
+            }
+            if (!(stat (src.c_str(), &buffer) == 0)) {
+                cout << "Could not stat " << src << "." << std::endl;
+                cout << "Please ensure " << GetInstallPath() << " exists and contains the linapple resource files." << std::endl;
+                throw std::runtime_error("could not copy resource files");
+            }
+            CopyFile(src, dest);
+        }
 
-		// Copy config options file
-    for( unsigned int i = 0; *files[ i ]; i++ ) {
-      string dest = GetUserFilePath();
-		  CopyFile(
-			  (GetInstallPath() + files[ i ]),
-        dest + files[ i ]
-      );
-    }
-	}
 	return bResult;
 }
 


### PR DESCRIPTION
The situation with this repository today is that if someone comes along and checks out the `master` branch of this repository and builds linapple and tries to run it before installing it, it will appear to sort of work, but won't actually get anywhere -- when you press Ctrl+F2 you'll be dropped to the monitor.

This is because it fills the userdir with bogus resource files.  They're bogus because it tries to copy them from `/etc/linapple` which will not, typically, exist on the user's system.  So it creates zero-sized files instead.  Linapple produces some error messages, but it doesn't abort; it continues to run, and tries to use these zero-sized resource files. Worse, the next time you run it, it won't even produce the error messages: it'll assume that, because you have a userdir, everything must be fine.

I encountered this here: https://github.com/linappleii/linapple/issues/20#issuecomment-416066930

This PR causes linapple to print a message about missing resource files and abort, if it can't stat the file it's supposed to copy.  It doesn't try to copy it if it already exists, or if it can't stat it.  This prevents creating bogus zero-sized files, and prevents trying to keep running without the necessary resource files.

It also removes two files from the list of files to copy that just aren't there (anymore?).

The intent of this change is to limit the amount of confusion this causes.