### PR TITLE
Fix for damaged RAMWorks emulation

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -858,7 +858,7 @@ LPBYTE MemGetAuxPtr (WORD offset)
 #ifdef RAMWORKS
   if ( ((SW_PAGE2 && SW_80STORE) || VideoGetSW80COL()) &&
     ( ( ((offset & 0xFF00)>=0x0400) &&
-    ((offset & 0xFF00)<=0700) ) ||
+    ((offset & 0xFF00)<=0x700) ) ||
     ( SW_HIRES && ((offset & 0xFF00)>=0x2000) &&
     ((offset & 0xFF00)<=0x3F00) ) ) ) {
     lpMem = (memshadow[(offset >> 8)] == (RWpages[0]+(offset & 0xFF00)))


### PR DESCRIPTION
(re: https://github.com/linappleii/linapple/issues/34)

Typo from upstream corrected in MemGetAuxPtr to correct visual flashes
during aux bank updates.