### PR TITLE
Use getopt_long.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,13 +13,12 @@ currently resides.
 
 ## Command Line Switches
 
-* `-d1 path/to/image1.dsk`: Specifies a disk image to load into FDD1 (drive 0)
-* `-d2 path/to/image2.dsk`: Specifies a disk image to load into FDD1 (drive 1)
+* `-1|--d1 path/to/image1.dsk`: Specifies a disk image to load into FDD1 (drive 0)
+* `-2|--d2 path/to/image2.dsk`: Specifies a disk image to load into FDD1 (drive 1)
+* `-b|--autoboot`: Boots the system automatically, rather than displaying the splash screen
 * `-f`: Specifies that the emulator should run in fullscreen mode
-* `-b`: Specifies that benchmark should be loaded (untested)
 * `-l`: Logs output to a file called AppleWin.log (untested)
-* `-m`: Disables direct sound (untested)
-* `-autoboot`: Boots the system automatically, rather than displaying the splash screen
+* `--benchmark`: Specifies that benchmark should be loaded (untested)
 
 ## Using LinApple
 

--- a/inc/Log.h
+++ b/inc/Log.h
@@ -8,4 +8,7 @@
   #endif
 #endif
 
+extern void LogInitialize();
 extern void LogOutput(LPCTSTR format, ...);
+extern void LogDestroy();
+

--- a/inc/config.h
+++ b/inc/config.h
@@ -29,6 +29,7 @@ class Config
 		bool CopyFile(std::string source, std::string dest);
 		std::string GetUserFilePath();
 		std::string GetRegistryPath();
+		void SetRegistryPath(std::string path);
 	protected:
 		std::string GetHomePath();
 		std::string GetInstallPath();

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -32,16 +32,41 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 //---------------------------------------------------------------------------
 
+void LogInitialize()
+{
+	g_fh = fopen("AppleWin.log", "a+t");	// Open log file (append & text g_nAppMode)
+	// Start of Unix(tm) specific code
+	struct timeval tv;
+	struct tm * ptm;
+	char time_str[40];
+	gettimeofday(&tv, NULL);
+	ptm = localtime(&tv.tv_sec);
+	strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", ptm);
+	// end of Unix(tm) specific code
+	fprintf(g_fh,"*** Logging started: %s\n",time_str);
+}
+
 void LogOutput(LPCTSTR format, ...)
 {
-    TCHAR output[256];
+	if (!g_fh) return;
 
-    va_list args;
-    va_start(args, format);
+	va_list args;
+	va_start(args, format);
 
-    vsnprintf(output, sizeof(output) - 1, format, args);
-//    OutputDebugString(output);
-    fprintf(stderr, "%s", output);
+	TCHAR output[512];
+
+	vsnprintf(output, sizeof(output) - 1, format, args);
+	//    OutputDebugString(output);
+	fprintf(g_fh, "%s", output);
+}
+
+void LogDestroy()
+{
+	if (g_fh)
+	{
+		fprintf(g_fh,"*** Logging ended\n\n");
+		fclose(g_fh);
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -32,6 +32,11 @@ std::string Config::GetRegistryPath()
 	return m_regFilePath.c_str();
 }
 
+void Config::SetRegistryPath(std::string path)
+{
+	m_regFilePath = path;
+}
+
 // Simple POSIX file copy
 bool Config::CopyFile(std::string srcFile, std::string destFile)
 {


### PR DESCRIPTION
By necessity:
  -d1 -> --d1
  -d2 -> --d2
  -autoboot -> --autoboot
  -b -> --benchmark
  -b -> synonym for --autoboot

See -h|--help.

Compatible with options in RetroPie release.
Some options are not mentioned, as they may not fully work yet.