### PR TITLE
Add missing semi-colon

### DIFF
--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -38,7 +38,7 @@ assets_t *assets = NULL;
 #ifdef ASSET_DIR
 static char system_assets[] = ASSET_DIR "/";
 #else
-static char system_assets[] = "./"
+static char system_assets[] = "./";
 #endif
 static char *system_exedir = NULL;
 


### PR DESCRIPTION
I discovered there is a missing semi-colon when I tried to compile using the debugging `CFLAGS`.

To recreate, comment out line 53 of `Makefile` and uncomment line 51. Run `make`. It fails with a syntax error.