### PR TITLE
Feature/handle debug profiling

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,3 +49,18 @@ linapple
 
 A directory name `linapple` can be found in your home directory. Edit the `linapple.conf` file.
 
+
+### Debugging and Profiling
+
+By default, the `make` command will compile an optimized version of `linapple`.
+
+It is possible to compile a version with debugging symbols. To do so, you must
+set the `DEBUG` environment variable:
+
+    DEBUG=1 make
+
+If you would like to also include extra code that writes profile information
+suitable for the analysis program `gprof`:
+
+    PROFILING=1 make
+

--- a/Makefile
+++ b/Makefile
@@ -45,26 +45,26 @@ CURL_CFLAGS = $(shell $(CURL_CONFIG) --cflags)
 CURL_LIBS = $(shell $(CURL_CONFIG) --libs)
 
 # By default, optimize the executable.
-CFLAGS      := -Wall -O3 -ansi -c
+CFLAGS := -Wall -O3 -ansi -c
 
 ifdef PROFILING
-CFLAGS      := -Wall -O0 -pg -ggdb -ansi -c
-LFLAGS      := -pg
+CFLAGS := -Wall -O0 -pg -ggdb -ansi -c
+LFLAGS := -pg
 endif
 
 ifdef DEBUG
-CFLAGS      := -Wall -O0 -ggdb -ansi -c -finstrument-functions
+CFLAGS := -Wall -O0 -ggdb -ansi -c -finstrument-functions
 endif
 
-CFLAGS      += -DASSET_DIR=\"$(ASSET_DIR)\" -DRESOURCE_INIT_DIR=\"$(RESOURCE_INIT_DIR)\"
-CFLAGS 		+= $(SDL_CFLAGS)
-CFLAGS 		+= $(CURL_CFLAGS)
+CFLAGS += -DASSET_DIR=\"$(ASSET_DIR)\" -DRESOURCE_INIT_DIR=\"$(RESOURCE_INIT_DIR)\"
+CFLAGS += $(SDL_CFLAGS)
+CFLAGS += $(CURL_CFLAGS)
 # Do not complain about XPMs
-CFLAGS		+= -Wno-write-strings
+CFLAGS += -Wno-write-strings
 
-LIB 				:= $(SDL_LIBS) $(CURL_LIBS) -lz -lzip
-INC         := -I$(INCDIR) -I/usr/local/include
-INCDEP      := -I$(INCDIR)
+LIB    := $(SDL_LIBS) $(CURL_LIBS) -lz -lzip
+INC    := -I$(INCDIR) -I/usr/local/include
+INCDEP := -I$(INCDIR)
 
 #---------------------------------------------------------------------------------
 #DO NOT EDIT BELOW THIS LINE

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,19 @@ CURL_CONFIG ?= curl-config
 CURL_CFLAGS = $(shell $(CURL_CONFIG) --cflags)
 CURL_LIBS = $(shell $(CURL_CONFIG) --libs)
 
-#PROFILING
-#CFLAGS      := -Wall -O0 -pg -ggdb -ansi -c
-#LFLAGS      := -pg
-#DEBUGGING
-#CFLAGS      := -Wall -O0 -ggdb -ansi -c -finstrument-functions
-#OPTIMIZED
-CFLAGS      := -Wall -O3 -ansi -c -DASSET_DIR=\"$(ASSET_DIR)\" -DRESOURCE_INIT_DIR=\"$(RESOURCE_INIT_DIR)\"
+# By default, optimize the executable.
+CFLAGS      := -Wall -O3 -ansi -c
+
+ifdef PROFILING
+CFLAGS      := -Wall -O0 -pg -ggdb -ansi -c
+LFLAGS      := -pg
+endif
+
+ifdef DEBUG
+CFLAGS      := -Wall -O0 -ggdb -ansi -c -finstrument-functions
+endif
+
+CFLAGS      += -DASSET_DIR=\"$(ASSET_DIR)\" -DRESOURCE_INIT_DIR=\"$(RESOURCE_INIT_DIR)\"
 CFLAGS 		+= $(SDL_CFLAGS)
 CFLAGS 		+= $(CURL_CFLAGS)
 # Do not complain about XPMs


### PR DESCRIPTION
This change allows a user to compile with debugging symbols, without needing to modify the `Makefile`, through the use of environment variables.

It helps to look at each commit separately as the second commit is simply reformatting.