### PR TITLE
Fix typo preventing configuration file from being used

### DIFF
--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -905,7 +905,7 @@ void LoadAllConfigurations(const char *userSpecifiedFilename)
   std::string userDir(home);
   mkdir((userDir + "/.config").c_str(), 0700);
   mkdir((userDir + "/.config/linapple").c_str(), 0700);
-  registry = fopen((userDir + "./config/linapple/linapple.conf").c_str(), "w+");
+  registry = fopen((userDir + "/.config/linapple/linapple.conf").c_str(), "w+");
 }
 
 //===========================================================================


### PR DESCRIPTION
Fixes #59. Might affect #57.

*WARNING* I haven't tested this change, but it does look like it's just a typo. Sorry for the problems it caused.