### PR TITLE
Joystick release fix / quantitization enhancement (keypad joystick emu.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TARGET      := linapple
 #The Directories, Source, Includes, Objects, Binary and Resources
 SRCDIR      := src
 INCDIR      := inc
-BUILDDIR    := obj
+BUILDDIR    := build
 TARGETDIR   := bin
 RESDIR      := res
 SRCEXT      := cpp

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -619,6 +619,9 @@ void  FrameDispatchMessage(SDL_Event * e) // process given SDL event
 {
   int mysym = e->key.keysym.sym; // keycode
   int mymod = e->key.keysym.mod; // some special keys flags
+  int myscancode = e->key.keysym.scancode; // some special keys flags
+  int mytype = e->key.type;
+  int mystate = e->key.state;
   int x,y;  // used for mouse cursor position
 
   switch (e->type) //type of SDL event
@@ -752,7 +755,7 @@ void  FrameDispatchMessage(SDL_Event * e) // process given SDL event
           // . WM_KEYDOWN[Left-Control], then:
           // . WM_KEYDOWN[Right-Alt]
           BOOL autorep  = 0; //previous key was pressed? 30bit of lparam
-          BOOL extended = (mysym >= 273); // 24bit of lparam - is an extended key, what is it???
+          BOOL extended = (mysym >= SDLK_UP); // 24bit of lparam - is an extended key, what is it???
           if ((!JoyProcessKey(mysym ,extended, TRUE, autorep)) && (g_nAppMode != MODE_LOGO))
             KeybQueueKeypress(mysym, NOT_ASCII);
         }
@@ -783,7 +786,9 @@ void  FrameDispatchMessage(SDL_Event * e) // process given SDL event
         // (http://sdl.beuc.net/sdl.wiki/SDL_KeyboardEvent)
         KeybToggleCapsLock();
       } else {  // Need to know what "extended" means, and what's so special about SDLK_UP?
-        JoyProcessKey(mysym,(mysym >= SDLK_UP && mysym <= SDLK_LEFT), FALSE, 0);
+        if (myscancode) { // GPH: Checking scan codes tells us if a key was REALLY released.
+          JoyProcessKey(mysym,(mysym >= SDLK_UP && mysym <= SDLK_LEFT), FALSE, 0);
+        }
       }
       break;
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -753,7 +753,7 @@ void  FrameDispatchMessage(SDL_Event * e) // process given SDL event
           // . WM_KEYDOWN[Right-Alt]
           BOOL autorep  = 0; //previous key was pressed? 30bit of lparam
           BOOL extended = (mysym >= 273); // 24bit of lparam - is an extended key, what is it???
-          if ((!JoyProcessKey(mysym ,extended, 1, autorep)) && (g_nAppMode != MODE_LOGO))
+          if ((!JoyProcessKey(mysym ,extended, TRUE, autorep)) && (g_nAppMode != MODE_LOGO))
             KeybQueueKeypress(mysym, NOT_ASCII);
         }
         else if (g_nAppMode == MODE_DEBUG)
@@ -782,8 +782,8 @@ void  FrameDispatchMessage(SDL_Event * e) // process given SDL event
         // GPH Fix caps lock toggle behavior.
         // (http://sdl.beuc.net/sdl.wiki/SDL_KeyboardEvent)
         KeybToggleCapsLock();
-      } else {  // mysym >= 300 (or 273????)- check for extended key, what is it EXACTLY???
-        JoyProcessKey(mysym,(mysym >= 273), 0, 0);
+      } else {  // Need to know what "extended" means, and what's so special about SDLK_UP?
+        JoyProcessKey(mysym,(mysym >= SDLK_UP && mysym <= SDLK_LEFT), FALSE, 0);
       }
       break;
 

--- a/src/SoundCore.cpp
+++ b/src/SoundCore.cpp
@@ -45,7 +45,7 @@ bool DSInit()
 {
   if(g_bDSAvailable) return true;  // do not need to repeat all process?? --bb
 //  const DWORD SPKR_SAMPLE_RATE = 44100; - defined in Common.h
-  g_bDSAvailable = SDLSoundDriverInit(SPKR_SAMPLE_RATE, 2048);// I just do not know what number of samples use.
+  g_bDSAvailable = SDLSoundDriverInit(SPKR_SAMPLE_RATE, 1024);// I just do not know what number of samples use.
   return g_bDSAvailable;  //
 }
 
@@ -387,7 +387,7 @@ double DSUploadBuffer(short* buffer, unsigned len)
 //  len *= 2; // stereo
   unsigned free = getBufferFree();
   if (len > free) {
-    std::cerr << "DEBUG overrun(1): " << len - free << std::endl;
+    // std::cerr << "DEBUG overrun(1): " << len - free << std::endl;
   }
   unsigned num = std::min(len, free); // ignore overrun (drop samples)
   if ((writeIdx + num) < bufferSize) {
@@ -418,7 +418,7 @@ void /*double*/ DSUploadMockBuffer(short* buffer, unsigned len)
 //  len *= 2; // stereo
   unsigned free = getBuffer2Free();
   if (len > free) {
-    std::cerr << "DEBUG overrun(2): " << len - free << std::endl;
+    // std::cerr << "DEBUG overrun(2): " << len - free << std::endl;
   }
   unsigned samplesToWrite = std::min(len, free); // ignore overrun (drop samples)
     // GPH Check for seam crossing on circular mockBuffer[].


### PR DESCRIPTION
Keypad Joystick emulation quantatization and fix to erroneous key-up when another key is pressed and released (the "Why are you stopping?   Go, GOOOO!" phenomenon).  I'm going to take it on faith that this includes the last three pushes to my repo, and not just the most recent incidental push to cleanup a sound-related debug message.  I'll leave it to others who are more expert-level users in Git to decide how to pull my changes in, should they be accepted.