### PR TITLE
Ported support for "Printer idle timeout" from AppleWin to LinApple

### DIFF
--- a/inc/Common.h
+++ b/inc/Common.h
@@ -90,6 +90,8 @@ enum AppMode_e {
 #define  REGVALUE_DISK_IMAGE2         "Disk Image 2"
 
 #define  REGVALUE_PPRINTER_FILENAME  "Parallel Printer Filename"
+#define  REGVALUE_PRINTER_APPEND     "Append to printer file"
+#define  REGVALUE_PRINTER_IDLE_LIMIT "Printer idle limit"
 
 #define  REGVALUE_PDL_XTRIM          "PDL X-Trim"
 #define  REGVALUE_PDL_YTRIM          "PDL Y-Trim"

--- a/inc/ParallelPrinter.h
+++ b/inc/ParallelPrinter.h
@@ -7,3 +7,9 @@ void PrintLoadRom(LPBYTE pCxRomPeripheral, UINT uSlot);
 void PrintReset();
 
 void PrintUpdate(DWORD);
+
+void Printer_SetIdleLimit(unsigned int Duration);
+
+unsigned int Printer_GetIdleLimit();
+
+extern bool g_bPrinterAppend;

--- a/linapple.conf.sample
+++ b/linapple.conf.sample
@@ -202,6 +202,23 @@
 
 	Parallel Printer Filename = Printer.txt
 
+##########################################################################
+#
+#	Printer timeout allows you to set the timeout in seconds after which
+#	the printer file is closed when no more printing activity is detected.
+#
+# Default is 10 seconds.
+
+	Printer idle limit = 10
+
+##########################################################################
+#
+#	Append to printer file: set to 1 to always append to an existing
+#   printer file. Set to 0 to overwrite an existing printer file.
+#
+# Default is 1 (append).
+
+	Append to printer file = 1
 
 ##########################################################################
 #

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -586,6 +586,10 @@ void LoadConfiguration()
       g_bSaveStateOnExit = (dwTmp != 0);
 
   if (registry)
+	if(LOAD(TEXT(REGVALUE_PRINTER_APPEND), &dwTmp))
+		g_bPrinterAppend = dwTmp ? true : false;
+
+  if (registry)
     if (LOAD(TEXT(REGVALUE_HDD_ENABLED), &dwTmp))
       hddenabled = (bool) dwTmp;// after MemInitialize
   //    HD_SetEnabled(dwTmp ? true : false);
@@ -648,6 +652,11 @@ void LoadConfiguration()
       szHDFilename = NULL;
     }
 
+  if (registry)
+  {
+	  if (RegLoadValue(TEXT("Configuration"), TEXT(REGVALUE_PRINTER_IDLE_LIMIT), 1, &dwTmp))
+		  Printer_SetIdleLimit(dwTmp);
+  }
 
   // for joysticks use default Y-,X-trims
   //   if(LOAD(TEXT(REGVALUE_PDL_XTRIM), &dwTmp))


### PR DESCRIPTION
The timeout after which the printer file is closed is now configurable.
Also, the printer file may now be overwritten or data maybe appended to the file.
(The current default behavior of LinApple was retained).