### PR TITLE
Enable support to emulate a standard Apple //e (non-enhanced)

### DIFF
--- a/linapple.conf.sample
+++ b/linapple.conf.sample
@@ -14,9 +14,9 @@
 #
 # Possible values are:
 #   0 - old Apple][, right out of the hands of Steve Wozniak and Steve Jobs in far 1977? year.
-#   1 - Apple][+	- same as Apple][ with somewhat enbettered functionality
-#   2 - Apple//e	- Enhanced Apple][ with 80-column mode and other useful additions
-#   3 - Apple//e enhanced	- currently same as Apple//e? Please, ask Tom Charlesworth about it.
+#   1 - Apple][+	- same as Apple][ with somewhat improved functionality.
+#   2 - Apple//e	- The improved Apple//e with original 6502 CPU and 80-column mode.
+#   3 - Apple//e enhanced	- The enhanced Apple//e, providing a newer 65C02 CPU and improved ROMs.
 #
 # Default is 3.
 

--- a/res/linapple.conf
+++ b/res/linapple.conf
@@ -10,12 +10,12 @@
 # First of all let us determine our machine type
 # that is:
 #	0 - old Apple][, right out of the hands of Steve Wozniak and Steve Jobs in far 1977? year.
-#	1 - Apple][+	- same as Apple][ with somewhat enbettered functionality
-#	2 - Apple//e	- Enhanced Apple][ with 80-column mode and other useful additions
-#	3 - Apple//e enhanced	- currently same as Apple//e? Please, ask Tom Charlesworth about it.
+#	1 - Apple][+	- same as Apple][ with somewhat improved functionality.
+#	2 - Apple//e	- The improved Apple//e with original 6502 CPU and 80-column mode.
+#	3 - Apple//e enhanced	- The enhanced Apple//e, providing a newer 65C02 CPU and improved ROMs.
 # Default is 3
 
-	Computer Emulation =	2
+	Computer Emulation =	3
 
 ####################################################################
 #

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -481,7 +481,7 @@ void LoadConfiguration()
         g_Apple2Type = A2TYPE_APPLE2PLUS;
         break;
       case 2:
-        g_Apple2Type = A2TYPE_APPLE2EEHANCED;
+        g_Apple2Type = A2TYPE_APPLE2E;
         break;
       default:
         g_Apple2Type = A2TYPE_APPLE2EEHANCED;


### PR DESCRIPTION
Support to emulate a standard Apple //e was not properly enabled. Some software actually requires an original, non-enhanced Apple //e with the original ROMs (due to dependencies to the original ROM code).
So far, the emulation options 2 and 3 made no difference - both enabled an enhanced IIe. There was no way to enable the standard IIe emulation.