### PR TITLE
Corrected debug compile options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ LFLAGS := -pg
 endif
 
 ifdef DEBUG
-CFLAGS := -Wall -O0 -ggdb -ansi -c -finstrument-functions
+CFLAGS := -Wall -O0 -ggdb -ansi -c -finstrument-functions -std=c++11
 endif
 
 CFLAGS += -DASSET_DIR=\"$(ASSET_DIR)\" -DRESOURCE_INIT_DIR=\"$(RESOURCE_INIT_DIR)\"


### PR DESCRIPTION
Debug mode also requires c++11 support when compiling, otherwise
compiling with DEBUG=1 aborts with a C++ error.