### PR TITLE
Fix segfaults on shutdown

### DIFF
--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -1088,9 +1088,9 @@ int main(int argc, char *argv[])
     PrintDestroy();
     sg_SSC.CommDestroy();
     CpuDestroy();
-    MemDestroy();
     SpkrDestroy();
     VideoDestroy();
+    MemDestroy();
     MB_Destroy();
     MB_Reset();
     sg_Mouse.Uninitialize(); // Maybe restarting due to switching slot-4 card from mouse to MB

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -1517,6 +1517,16 @@ void VideoChooseColor() {
 
 
 void VideoDestroy() {
+  // GPH Multithreaded
+  {
+    void *result;
+    video_worker_terminate_ = true;
+    if (video_worker_active_)
+      pthread_join(video_worker_thread_,&result);
+    video_worker_active_ = false;
+  }
+  // END GPH
+
   // Just free our SDL surfaces and free vidlastmem
   // DESTROY BUFFERS
   VirtualFree(vidlastmem, 0, MEM_RELEASE);
@@ -1553,14 +1563,6 @@ void VideoDestroy() {
     SDL_FreeSurface(charset40);
   }
   charset40 = NULL;
-
-  // GPH Multithreaded
-  {
-    void *result;
-    video_worker_terminate_ = true;
-    pthread_join(video_worker_thread_,&result);
-  }
-  // END GPH
 }
 
 void VideoDisplayLogo() {


### PR DESCRIPTION
Fixes two segfaults when shutting down the emulator.
Doesn't change much, since the segfaults only happened just before the process exited anyway, but it's still nice to see the emulator quitting cleanly.
First issue affects the video_worker_thread (always crashed when shutting down in single threaded mode). The other segfault occasionally happened due to a dependency of the Video module on a pointer of the Memory module (so VideoDestroy must be called before MemDestroy).