### PR TITLE
Added capability to set the PDL(0) trim in real time using Right-Cont…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,7 @@ currently resides.
 | Numpad +       | Increase emulation speed.                                        |
 | Numpad -       | Decrease emulation speed.                                        |
 | Numpad *       | Reset emulation speed.                                           |
+| RtCtrl+Numpad  | Adjust pdl TrimX (4, 6) or TrimY (2, 8)                          |
 
 **Warning**: Fullscreen mode does not properly exit in multi-monitor setups.  (This is a bug in SDL 1.2.)
 

--- a/inc/Joystick.h
+++ b/inc/Joystick.h
@@ -27,6 +27,8 @@ void JoyInitialize();
 
 void JoyShutDown();
 
+void JoyUpdateTrimViaKey(int);
+
 BOOL JoyProcessKey(int, BOOL, BOOL, BOOL);
 
 void JoyReset();

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -307,7 +307,7 @@ void FrameDispatchMessage(SDL_Event *e) {// process given SDL event
       break;
 
     case SDL_KEYDOWN:
-      if (mysym >= SDLK_0 && mysym <= SDLK_9 && mymod & KMOD_CTRL) {
+      if (mysym >= SDLK_0 && mysym <= SDLK_9 && mymod & KMOD_LCTRL) {
         FrameQuickState(mysym - SDLK_0, mymod);
         break;
       }
@@ -375,8 +375,14 @@ void FrameDispatchMessage(SDL_Event *e) {// process given SDL event
           // . WM_KEYDOWN[Right-Alt]
           BOOL autorep = 0; //previous key was pressed? 30bit of lparam
           BOOL extended = (mysym >= SDLK_UP); // 24bit of lparam - is an extended key, what is it???
-          if ((!JoyProcessKey(mysym, extended, TRUE, autorep)) && (g_nAppMode != MODE_LOGO)) {
-            KeybQueueKeypress(mysym, NOT_ASCII);
+          if (mymod & KMOD_RCTRL)     // GPH: Update trim?
+          {
+            JoyUpdateTrimViaKey(mysym);
+          } else {
+            // Regular joystick movement
+            if ((!JoyProcessKey(mysym, extended, TRUE, autorep)) && (g_nAppMode != MODE_LOGO)) {
+              KeybQueueKeypress(mysym, NOT_ASCII);
+            }
           }
         } else if (g_nAppMode == MODE_DEBUG) {
           DebuggerProcessKey(mysym);
@@ -587,6 +593,7 @@ void ProcessButtonClick(int button, int mod)
 
     case BTN_DRIVE1:
     case BTN_DRIVE2:
+      JoyReset();
       if (mod & KMOD_SHIFT) {
         if (mod & KMOD_ALT) {
           HD_FTP_Select(button - BTN_DRIVE1);// select HDV image through FTP


### PR DESCRIPTION
…rol Numpad2/4/6/8.  This helps with games like Boulder Dash where right and down dont elicit full force (and thus the player character moves slowly rendering the game unplayable).