### PR TITLE
Fixed obscure bug affecting use of the alterate zero page (bank 1 ZP,…

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -647,11 +647,14 @@ static void UpdatePaging(BOOL initialize, BOOL updatewriteonly) {
 
   for (loop = 0xD0; loop < 0xE0; loop++) {
     int bankoffset = (SW_BANK2 ? 0 : 0x1000);
-    memshadow[loop] = SW_HIGHRAM ? SW_ALTZP ? memaux + (loop << 8) - bankoffset : memmain + (loop << 8) - bankoffset :
-                      memrom + ((loop - 0xD0) * 0x100);
+    memshadow[loop] = SW_HIGHRAM ? SW_BANK2 ? memaux+(loop << 8)-bankoffset
+                        : memmain+(loop << 8)-bankoffset
+                  : memrom+((loop-0xD0) * 0x100);
 
-    memwrite[loop] = SW_WRITERAM ? SW_HIGHRAM ? mem + (loop << 8) : SW_ALTZP ? memaux + (loop << 8) - bankoffset :
-                                                                    memmain + (loop << 8) - bankoffset : NULL;
+    memwrite[loop]  = SW_WRITERAM  ? SW_HIGHRAM  ? mem+(loop << 8)
+                            : SW_BANK2  ? memaux+(loop << 8)-bankoffset
+                                  : memmain+(loop << 8)-bankoffset
+                    : NULL;
   }
 
   for (loop = 0xE0; loop < 0x100; loop++) {


### PR DESCRIPTION
… ALTZP) that existed in both LinApple and AppleWin.  @tomcw has been alerted to the issue.