### PR TITLE
add missing ImageMagick to the requirements to compile on Fedora

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,7 @@ sudo apt-get install git libzip-dev libsdl1.2-dev libsdl-image1.2-dev libcurl4-o
 
 ```bash
 sudo dnf install git SDL-devel SDL_image-devel libcurl-devel libzip-devel
+ImageMagick
 ```
 
 ### Clone


### PR DESCRIPTION
When trying to compile on Fedora without ImageMagick you get : 
```
[ludovic@saraan linapple]$ make
convert -flatten "res/charset40_british.png" "res/charset40_british.xpm"
/bin/sh: convert: command not found
make: *** [Makefile:187: res/charset40_british.xpm] Error 127
```

fixing this by fixing the INSTALL.md doc