### PR TITLE
XDG User Config File Fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+XXXX mouse capture exit by function key
+
 # LinApple
 
 LinApple is an emulator for Apple ][, Apple ][+, Apple //e, and Enhanced Apple //e computers.
@@ -24,6 +26,9 @@ currently resides.
 * `--benchmark`: Specifies that benchmark should be loaded (untested)
 
 ## Using LinApple
+
+Clicking in the LinApple window will capture the mouse. It may be
+released by pressing any function key.
 
 | Key            | Function                                                         |
 | -------------- | -----------------------------------------------------------------|

--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,9 @@ currently resides.
 
 ## Command Line Switches
 
+* `-h|--help`: Print command-line options and exit.
+* `--conf path/to/file.conf`: Use only the specified configuration file.
+  (The standard configuration file search is not done.)
 * `-1|--d1 path/to/image1.dsk`: Specifies a disk image to load into FDD1 (drive 0)
 * `-2|--d2 path/to/image2.dsk`: Specifies a disk image to load into FDD1 (drive 1)
 * `-b|--autoboot`: Boots the system automatically, rather than displaying the splash screen

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -943,16 +943,19 @@ void LoadAllConfigurations(const char *userSpecifiedFilename)
     return;
   }
 
-  if (!home) {
-    std::cerr << "WARNING!" << " No HOME set and no known location for user config files."
-              << " This can lead to unexpected behavior, even program crashes." << std::endl;
+  if (xdgConfigHome.length() == 0) {
+    std::cerr << "WARNING!"
+        << " Neither XDG_CONFIG_HOME nor HOME is set and no user config"
+        << " files were found."
+        << " This can lead to unexpected behavior, even program crashes."
+        << std::endl;
     return;
   }
 
   std::string userDir(home);
-  mkdir((userDir + "/.config").c_str(), 0700);
-  mkdir((userDir + "/.config/linapple").c_str(), 0700);
-  registry = fopen((userDir + "/.config/linapple/linapple.conf").c_str(), "w+");
+  mkdir(xdgConfigHome.c_str(), 0700);
+  mkdir((xdgConfigHome + "/linapple").c_str(), 0700);
+  registry = fopen((xdgConfigHome + "/linapple/linapple.conf").c_str(), "w+");
 }
 
 void RegisterExtensions()

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -909,16 +909,16 @@ void LoadAllConfigurations(const char *userSpecifiedFilename)
     xdgConfigHome = std::string(home) + "/.config";
   }
 
-  std::vector <std::string> configDir;
-  configDir.push_back(xdgConfigDirs + "/linapple/linapple.conf");
+  std::vector <std::string> configFiles;
+  configFiles.push_back(xdgConfigDirs + "/linapple/linapple.conf");
   if (home) {
     // Suppport old locations under HOME.
-    configDir.push_back(std::string(home) + "/linapple/linapple.conf");
-    configDir.push_back(std::string(home) + "/.linapple/linapple.conf");
+    configFiles.push_back(std::string(home) + "/linapple/linapple.conf");
+    configFiles.push_back(std::string(home) + "/.linapple/linapple.conf");
   }
 
   std::string lastSuccessfulUserConfig;
-  for (std::vector<std::string>::reverse_iterator it = configDir.rbegin(); it != configDir.rend(); it++) {
+  for (std::vector<std::string>::reverse_iterator it = configFiles.rbegin(); it != configFiles.rend(); it++) {
     registry = fopen((*it).c_str(), "r");
     if (!registry) {
       continue;

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -916,6 +916,7 @@ void LoadAllConfigurations(const char *userSpecifiedFilename)
     configFiles.push_back(std::string(home) + "/linapple/linapple.conf");
     configFiles.push_back(std::string(home) + "/.linapple/linapple.conf");
   }
+  configFiles.push_back(xdgConfigHome + "/linapple/linapple.conf");
 
   std::string lastSuccessfulUserConfig;
   for (std::vector<std::string>::reverse_iterator it = configFiles.rbegin(); it != configFiles.rend(); it++) {

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -970,6 +970,7 @@ void PrintHelp()
          "LinApple is an emulator for Apple ][, Apple ][+, Apple //e, and Enhanced Apple //e computers.\n"
          "\n"
          "  -h|--help      show this help message\n"
+         "  --conf <file>  use <file> instead of any default config files\n"
          "  --d1 <file>    insert disk image into first drive\n"
          "  --d2 <file>    insert disk image into second drive\n"
          "  -b|--autoboot  boot/reset at startup\n"


### PR DESCRIPTION
`LoadAllConfigurations()` was not loading the XDG user config file (default $HOME/.config/linapple/linapple.conf) and, worse yet, wiping out the contents of that default path (whether or not it was the actual XDG user path) if no other user config file was found. This fixes both of these problems.

See the commit messages for full details. The diffs will also be much more clear if you read the diffs for each individual commit.