### PR TITLE
give the --conf switch so people are aware when they type -h

### DIFF
--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -988,6 +988,7 @@ void PrintHelp()
          "  -r PAGES       allocate PAGES to Ramworks (1-127)\n"
          #endif
          "  --benchmark    benchmark and quit\n"
+         "  --conf <file>  conf file for the emulator\n"
          "\n");
 }
 


### PR DESCRIPTION
When trying to remember how to use the config file (I use french keyboard, and thus need the config file). -h doesn't display what the switch for the file is. Adding this to make users life easier.