### PR TITLE
Fixed AltZP access / completed partial revert from earlier commit

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -676,7 +676,7 @@ void MemUpdatePaging(bool initialize, bool updatewriteonly) {
 
   for (loop = 0xD0; loop < 0xE0; loop++) {
     int bankoffset = (SW_HRAM_BANK2 ? 0 : 0x1000);
-#if 0
+#if 1
 		memshadow[loop] = SW_HIGHRAM
 												? SW_ALTZP
 													?	memaux + (loop << 8) - bankoffset


### PR DESCRIPTION
See commit 0ce4b71334966da2285967cc9215a1a3a14b0395 or issue #96.
The AltZP code was only partially reverted with the commit above.
Accidentally there is still an "#if 0...#else..." activating the broken code
for the D0.. address range. The revert only affected the E0.. address range.
Games like GATO or Karteka did no longer load (since their loading routine
was using a zero page pointer to write data to the affected address range).