### PR TITLE
Bugfix: memory leaks in Registry

### DIFF
--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -411,6 +411,7 @@ void SetDiskImageDirectory(char *regKey, int driveNumber)
   char *szHDFilename = NULL;
   if (RegLoadString(TEXT("Configuration"), TEXT(regKey), 1, &szHDFilename, MAX_PATH)) {
     if (!ValidateDirectory(szHDFilename)) {
+      free(szHDFilename);
       RegSaveString(TEXT("Configuration"), TEXT(regKey), 1, "/");
       RegLoadString(TEXT("Configuration"), TEXT(regKey), 1, &szHDFilename, MAX_PATH);
     }
@@ -433,7 +434,7 @@ void setAutoBoot()
 void LoadConfiguration()
 {
   if (registry) {
-    DWORD dwComputerType;
+    DWORD dwComputerType = g_Apple2Type;
     LOAD(TEXT("Computer Emulation"), &dwComputerType);
 
     switch (dwComputerType) {


### PR DESCRIPTION
These are caused by callers of the following functions failing to `free()` the returned strings:
* `RegLoadString()`
* `php_trim()`

