### PR TITLE
Bug fixes: dependence on uninitialized values

### DIFF
--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -869,7 +869,7 @@ static DWORD Cpu65C02(DWORD uTotalCycles)
   WORD val;
   AF_TO_EF
   ULONG uExecutedCycles = 0;
-  BOOL bSlowerOnPagecross;    // Set if opcode writes to memory (eg. ASL, STA)
+  BOOL bSlowerOnPagecross = FALSE;    // Set if opcode writes to memory (eg. ASL, STA)
   WORD base;
 
   do {
@@ -2165,7 +2165,7 @@ static DWORD Cpu6502(DWORD uTotalCycles)
   WORD val;
   AF_TO_EF
   ULONG uExecutedCycles = 0;
-  BOOL bSlowerOnPagecross;    // Set if opcode writes to memory (eg. ASL, STA)
+  BOOL bSlowerOnPagecross = FALSE;    // Set if opcode writes to memory (eg. ASL, STA)
   WORD base;
 
   do {


### PR DESCRIPTION
`valgrind` detected some "Conditional jump or move depends on uninitialised value(s)".  The patch ba79094097c6793f19c534a28c15480a18deb0ac removed them.
