### PR TITLE
Refactoring sound core

### DIFF
--- a/inc/SoundCore.h
+++ b/inc/SoundCore.h
@@ -11,7 +11,7 @@ void DSUninit();  // uninit SDL_Auidio
 
 void SoundCore_SetFade(int how);  //
 
-double DSUploadBuffer(short *buffer, unsigned len);
+void DSUploadBuffer(short *buffer, unsigned len);
 
 void DSUploadMockBuffer(short *buffer, unsigned len);  // Upload Mockingboard data
 


### PR DESCRIPTION
35156155f75218df99680480df982e210c18feb1 is a refactoring of `SoundCore.cpp`.  The duplicated code for manipulating the sound buffers for the the speaker and mocking board have been unified.  The implementation has also been modernized to use std::copy(), std::transform() to avoid looping with raw pointers.