### PR TITLE
bug fixes: memory leaks in Registry

### DIFF
--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -411,6 +411,7 @@ void SetDiskImageDirectory(char *regKey, int driveNumber)
   char *szHDFilename = NULL;
   if (RegLoadString(TEXT("Configuration"), TEXT(regKey), 1, &szHDFilename, MAX_PATH)) {
     if (!ValidateDirectory(szHDFilename)) {
+      free(szHDFilename);
       RegSaveString(TEXT("Configuration"), TEXT(regKey), 1, "/");
       RegLoadString(TEXT("Configuration"), TEXT(regKey), 1, &szHDFilename, MAX_PATH);
     }

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -93,24 +93,31 @@ bool ReturnKeyValue(char *line, char **key, char **value) {
   // functions returns trimmed key and value
   char *br = strchr(line, '=');
   if (!br) {
+    *key = *value = NULL;
     return false; // no sign of '=' sign. Sorry for some kalambur --bb
   }
   *br = '\0'; // cut the string where '=' is (or was)
   br++; //to the value
   *key = php_trim(line, strlen(line)); // trim those strings from beginning and trailing spaces
   if (*key != NULL && **key == '#') {
+    free(*key);
+    *key = *value = NULL;
     return false; // omit comments (lines with #)
   }
   *value = php_trim(br, strlen(br));
   if (*key && *value) {
     return true;
   }
+
+  free(*key);
+  free(*value);
+  *key = *value = NULL;
   return false;
 }
 
 #define BUFSIZE 256
 
-char *ReadRegString(char *key) {
+char *ReadRegString(const char *key) {
   // reads key for given value from the registry. Hmmm. What registry in Linux? I donna. --bb
   fseek(registry, 0, SEEK_SET); //to the start of file
   char *mkey;
@@ -119,24 +126,28 @@ char *ReadRegString(char *key) {
   int nkey = strlen(key);  // length of key
   while (fgets(line, BUFSIZE, registry)) {
     if (ReturnKeyValue(line, &mkey, &mvalue) && (!strncmp(mkey, key, nkey))) {
+      free(mkey);
       return mvalue;
     }
+    free(mkey);
+    free(mvalue);
   }
   return NULL; // key has not been found in registry?
 }
 
 bool RegLoadString(LPCTSTR section, LPCTSTR key, bool peruser, char **buffer, unsigned int chars) {
   // will ignore section, per user
-  bool success = false;
   char *value;
-  value = ReadRegString((char *) key); // read value for a given keyhandle
+  value = ReadRegString(key); // read value for a given keyhandle
   if (value) {
-    success = true;
     if (strlen(value) > chars)
       value[chars] = '\0'; // cut string
-    *buffer = strdup(value);
+    *buffer = value;
+    return true;
   }
-  return success;
+
+  *buffer = NULL;
+  return false;
 }
 
 bool RegLoadValue(LPCTSTR section, LPCTSTR key, bool peruser, unsigned int *value) {
@@ -149,6 +160,7 @@ bool RegLoadValue(LPCTSTR section, LPCTSTR key, bool peruser, unsigned int *valu
     return 0;
   }
   *value = (unsigned int) atoi(sztmp);
+  free(sztmp);
   return 1;
 }
 


### PR DESCRIPTION
These are caused by callers of the following functions failing to `free()` the returned strings:
* `RegLoadString()`
* `php_trim()`

was: #160
