### PR TITLE
Rollback of 6aa645a, and move to C99 types in wincompat.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ LFLAGS := -pg
 endif
 
 ifdef DEBUG
-CFLAGS := -Wall -O0 -ggdb -ansi -c -finstrument-functions -std=c++11
+CFLAGS := -O0 -ggdb -ansi -c -finstrument-functions -std=c++11 -Wno-write-strings -Werror
 endif
 
 CFLAGS += -DASSET_DIR=\"$(DATADIR)\" -DVERSIONSTRING=\"$(VERSION)\"
@@ -113,6 +113,7 @@ clean:
 #https://www.gnu.org/prep/standards/html_node/Standard-Targets.html
 distclean: clean
 	@$(RM) -rf build
+	@find . -type f -iname '*~' -exec rm -f {} \;
 	@$(RM) $(TARGET)-$(VERSION).deb
 
 #Pull in dependency info for *existing* .o files

--- a/inc/CPU.h
+++ b/inc/CPU.h
@@ -1,24 +1,23 @@
 #pragma once
 
 typedef struct _regsrec {
-  unsigned char a;   // accumulator
-  unsigned char x;   // index X
-  unsigned char y;   // index Y
-  unsigned char ps;  // processor status
-  unsigned short pc;  // program counter
-  unsigned short sp;  // stack pointer
-  unsigned char bJammed; // CPU has crashed (NMOS 6502 only)
+  UINT8 a;   // accumulator
+  UINT8 x;   // index X
+  UINT8 y;   // index Y
+  UINT8 ps;  // processor status
+  UINT16 pc;  // program counter
+  UINT16 sp;  // stack pointer
+  UINT8 bJammed; // CPU has crashed (NMOS 6502 only)
 } regsrec, *regsptr;
 
 extern regsrec regs;
-extern unsigned __int64
-g_nCumulativeCycles;
+extern UINT64 g_nCumulativeCycles;
 
 void CpuDestroy();
 
 void CpuCalcCycles(ULONG nExecutedCycles);
 
-unsigned int CpuExecute(unsigned int);
+DWORD CpuExecute(DWORD);
 
 ULONG CpuGetCyclesThisFrame(ULONG nExecutedCycles);
 
@@ -40,6 +39,5 @@ void CpuNmiDeassert(eIRQSRC Device);
 
 void CpuReset();
 
-unsigned int CpuGetSnapshot(SS_CPU6502 *pSS);
-
-unsigned int CpuSetSnapshot(SS_CPU6502 *pSS);
+DWORD CpuGetSnapshot(SS_CPU6502 *pSS);
+DWORD CpuSetSnapshot(SS_CPU6502 *pSS);

--- a/inc/Structs.h
+++ b/inc/Structs.h
@@ -27,8 +27,7 @@ typedef struct {
   unsigned char P;
   unsigned char S;
   USHORT PC;
-  unsigned __int64
-  g_nCumulativeCycles;
+  UINT64 g_nCumulativeCycles;
   // IRQ = OR-sum of all interrupt sources
 } SS_CPU6502;
 
@@ -47,8 +46,7 @@ typedef struct {
 } SS_IO_Comms;
 
 typedef struct {
-  unsigned __int64
-  g_nJoyCntrResetCycle;
+  UINT64 g_nJoyCntrResetCycle;
 } SS_IO_Joystick;
 
 typedef struct {
@@ -57,8 +55,7 @@ typedef struct {
 } SS_IO_Keyboard;
 
 typedef struct {
-  unsigned __int64
-  g_nSpkrLastCycle;
+  UINT64 g_nSpkrLastCycle;
 } SS_IO_Speaker;
 
 typedef struct {

--- a/inc/stdafx.h
+++ b/inc/stdafx.h
@@ -13,13 +13,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <inttypes.h>
+#include <stdint.h>
 
 #ifndef _WIN32
-
-#include "wincompat.h"
-
+#  include "wincompat.h"
 #else
-#include <windows.h>
+#  include <windows.h>
 #endif
 
 #include <SDL.h>

--- a/inc/wincompat.h
+++ b/inc/wincompat.h
@@ -17,30 +17,40 @@
 #ifndef _WINDEF_
 #define _WINDEF_
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #ifndef BASETYPES
 #define BASETYPES
-typedef unsigned int ULONG;
-typedef ULONG *PULONG;
-typedef unsigned short USHORT;
-typedef USHORT *PUSHORT;
-typedef unsigned char UCHAR;
-typedef UCHAR *PUCHAR;
-typedef char *PSZ;
+typedef uint32_t ULONG;
+typedef uint32_t *PULONG;
+typedef uint16_t USHORT;
+typedef uint16_t *PUSHORT;
+typedef uint8_t UCHAR;
+typedef uint8_t *PUCHAR;
+typedef int8_t *PSZ;
+typedef char CHAR;	// for strings
+typedef int16_t SHORT;
+typedef int32_t LONG;
 #endif
 
 
 typedef void *HANDLE;
-typedef signed short INT16;    // why there was char instead of short? --bb ??????????????????
-typedef unsigned short UINT16;    // why there was char instead of short? --bb ??????????????????? 0_0
-#define __int64 long long
 
-typedef unsigned int UINT32;
-typedef unsigned char UINT8;
-typedef int INT32;
+typedef int16_t INT16;    // why there was char instead of short? --bb ??????????????????
+typedef int32_t INT32;
+
+typedef uint8_t UINT8;
+typedef uint16_t UINT16;    // why there was char instead of short? --bb ??????????????????? 0_0
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+
+typedef uint8_t BYTE;		// 8 bits
+typedef uint16_t WORD;		// 16 bits
+typedef uint32_t DWORD;		// 32 bits
+
 
 #define MAX_PATH          260
 
@@ -70,6 +80,7 @@ typedef int INT32;
 
 #define far
 #define near
+
 #if (!defined(_MAC)) && ((_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED))
 #define pascal __stdcall
 #else
@@ -84,18 +95,18 @@ typedef int INT32;
 #define CONST               const
 #endif
 
-typedef unsigned int DWORD;
-typedef int BOOL;
-typedef unsigned char BYTE;
-typedef unsigned short WORD;
 typedef float FLOAT;
 typedef FLOAT *PFLOAT;
+
+typedef uint8_t BOOL;
 typedef BOOL near *PBOOL;
 typedef BOOL far *LPBOOL;
 typedef BYTE near *PBYTE;
 typedef BYTE far *LPBYTE;
-typedef int near *PINT;
-typedef int far *LPINT;
+
+typedef uint16_t near *PINT;	// were implicit 16 bit ints
+typedef uint16_t far *LPINT;
+
 typedef WORD near *PWORD;
 typedef WORD far *LPWORD;
 typedef long far *LPLONG;
@@ -103,10 +114,6 @@ typedef DWORD near *PDWORD;
 typedef DWORD far *LPDWORD;
 typedef void far *LPVOID;
 typedef CONST void far *LPCVOID;
-
-typedef int INT;
-typedef unsigned int UINT;
-typedef unsigned int *PUINT;
 
 #define MAKEWORD(a, b)      ((WORD)(((BYTE)(a)) | ((WORD)((BYTE)(b))) << 8))
 #define MAKELONG(a, b)      ((LONG)(((WORD)(a)) | ((DWORD)((WORD)(b))) << 16))
@@ -118,16 +125,13 @@ typedef unsigned int *PUINT;
 typedef DWORD COLORREF;
 typedef DWORD *LPCOLORREF;
 
-
 // WINNT
 #ifndef VOID
 #define VOID void
-typedef char CHAR;
-typedef short SHORT;
-typedef int LONG;
+#endif
+
 typedef SHORT *PSHORT;
 typedef LONG *PLONG;
-#endif
 
 
 typedef char WCHAR;    // wc,   16-bit UNICODE character

--- a/src/6821.cpp
+++ b/src/6821.cpp
@@ -18,8 +18,7 @@
 //    information, if you find new information we would appreciate if you made it
 //    freely available as well.
 //
-
-#include "wincompat.h"
+#include "stdafx.h"
 #include "6821.h"
 
 // Ctrl-A(B) register bit mask define

--- a/src/AY8910.cpp
+++ b/src/AY8910.cpp
@@ -28,6 +28,8 @@
 //    freely available as well.
 //
 
+#include <inttypes.h>
+#include <stdint.h>
 #include "wincompat.h"
 #include <stdio.h>
 #include <string.h>

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -166,13 +166,13 @@ void ContinueExecution()
   if (nCyclesWithFeedback < 0) {
     nCyclesWithFeedback = 0;
   }
-  const unsigned int uCyclesToExecuteWithFeedback = (nCyclesWithFeedback >= 0) ? nCyclesWithFeedback
+  const DWORD uCyclesToExecuteWithFeedback = (nCyclesWithFeedback >= 0) ? nCyclesWithFeedback
                                        : 0;
 
-  const unsigned int uCyclesToExecute = (g_nAppMode == MODE_RUNNING)   ? uCyclesToExecuteWithFeedback
+  const DWORD uCyclesToExecute = (g_nAppMode == MODE_RUNNING)   ? uCyclesToExecuteWithFeedback
                           /* MODE_STEPPING */ : 0;
 
-  unsigned int uActualCyclesExecuted = CpuExecute(uCyclesToExecute);
+  DWORD uActualCyclesExecuted = CpuExecute(uCyclesToExecute);
   g_dwCyclesThisFrame += uActualCyclesExecuted;
 
   cyclenum = uActualCyclesExecuted;

--- a/src/Debugger/Debug.cpp
+++ b/src/Debugger/Debug.cpp
@@ -8311,7 +8311,7 @@ void ProfileFormat( bool bExport, ProfileFormat_e eFormatMode )
     if (bExport)
     {
       // Note: 2 extra dummy columns are inserted to keep Addressing Mode in same column
-      sprintf( sAddress, "%s%s\"%s\"", sSeperator1, sSeperator1, g_aOpmodes[ nOpmode ].m_sName );
+      sprintf( sAddress, "%.*s%.*s\"%.*s\"", int(strlen(sSeperator1)), sSeperator1, int(strlen(sSeperator1)), sSeperator1, int(strlen(g_aOpmodes[ nOpmode ].m_sName)), g_aOpmodes[ nOpmode ].m_sName );
     }
     else // not qouted if dumping to console
     {
@@ -8790,7 +8790,10 @@ void DebugInitialize()
     doneAutoRun = true;
     std::string pathname = g_sProgramDir;
     pathname += "DebuggerAutoRun.txt";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(g_aArgs[1].sArg, pathname.c_str(), MAX_ARG_LEN);
+#pragma GCC diagnostic pop
     g_bReportMissingScripts = false;
     CmdOutputRun(1);
     g_bReportMissingScripts = true;

--- a/src/Debugger/Debug.cpp
+++ b/src/Debugger/Debug.cpp
@@ -200,7 +200,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
   ProfileOpcode_t g_aProfileOpcodes[ NUM_OPCODES ];
   ProfileOpmode_t g_aProfileOpmodes[ NUM_OPMODES ];
-  unsigned __int64 g_nProfileBeginCycles = 0; // g_nCumulativeCycles // PROFILE RESET
+  UINT64 g_nProfileBeginCycles = 0; // g_nCumulativeCycles // PROFILE RESET
 
   const std::string g_FileNameProfile = TEXT("Profile.txt"); // changed from .csv to .txt since Excel doesn't give import options.
   int   g_nProfileLine = 0;

--- a/src/Debugger/Debugger_DisassemblerData.cpp
+++ b/src/Debugger/Debugger_DisassemblerData.cpp
@@ -129,7 +129,10 @@ unsigned short _CmdDefineByteRange(int nArgs,int iArg,DisasmData_t & tData_)
 
 	// TODO: Note: need to call ConsoleUpdate(), as may print symbol has been updated
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 	strncpy( tData_.sSymbol, pSymbolName, sizeof(tData_.sSymbol));
+#pragma GCC diagnostic pop
 
 	return nAddress;
 }

--- a/src/Debugger/Debugger_Display.h
+++ b/src/Debugger/Debugger_Display.h
@@ -86,7 +86,7 @@
 	extern char g_aDebuggerVirtualTextScreen[ DEBUG_VIRTUAL_TEXT_HEIGHT ][ DEBUG_VIRTUAL_TEXT_WIDTH ];
 	extern size_t Util_GetDebuggerText( char* &pText_ ); // Same API as Util_GetTextScreen()
 
-	extern unsigned __int64 g_nCumulativeCycles;
+	extern UINT64 g_nCumulativeCycles;
 	class VideoScannerDisplayInfo
 	{
 	public:
@@ -98,7 +98,7 @@
 		bool isHorzReal;
 		bool isAbsCycle;
 
-		unsigned __int64 lastCumulativeCycles;
+		UINT64 lastCumulativeCycles;
 		unsigned int cycleDelta;
 	};
 

--- a/src/Debugger/Debugger_Help.cpp
+++ b/src/Debugger/Debugger_Help.cpp
@@ -89,7 +89,10 @@ bool TryStringCat ( char * pDst, LPCSTR pSrc, const int nDstSize )
 		return false;
 	}
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 	_tcsncat( pDst, pSrc, nChars );
+#pragma GCC diagnostic pop
 	return true;
 }
 
@@ -103,7 +106,10 @@ int StringCat ( char * pDst, LPCSTR pSrc, const int nDstSize )
 	int nSpcDst = nDstSize - nLenDst;
 	int nChars  = MIN( nLenSrc, nSpcDst );
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 	_tcsncat( pDst, pSrc, nChars );
+#pragma GCC diagnostic pop
 
 	bool bOverflow = (nSpcDst < nLenSrc);
 	if (bOverflow)
@@ -297,12 +303,12 @@ void Help_KeyboardShortcuts()
 }
 
 
-void _ColorizeHeader(
-	char * & pDst,const char * & pSrc,
-	const char * pHeader, const int nHeaderLen )
+void _ColorizeHeader( char * & pDst, const char * & pSrc, const char * pHeader, const int nHeaderLen )
 {
 	int nLen;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 	nLen = strlen( CHC_USAGE );
 	strcpy( pDst, CHC_USAGE );
 	pDst += nLen;
@@ -323,6 +329,7 @@ void _ColorizeHeader(
 	nLen = strlen( CHC_DEFAULT );
 	strcpy( pDst, CHC_DEFAULT );
 	pDst += nLen;
+#pragma GCC diagnostic pop
 }
 
 
@@ -378,7 +385,7 @@ bool Colorize( char * pDst, const char * pSrc )
 		return false;
 
 	const char sNote [] = "Note:";
-	const int  nNote    = sizeof( sNote ) - 1;
+	const int  nNote    = sizeof( sNote ) - 1; 
 
 	const char sSeeAlso[] = "See also:";
 	const char nSeeAlso   = sizeof( sSeeAlso ) - 1;
@@ -483,7 +490,7 @@ inline bool ConsoleColorizePrint( char* colorizeBuf, size_t /*colorizeBufSz*/,
                                   const char* pText )
 {
    if (!Colorize(colorizeBuf, pText)) return false;
-   return ConsolePrint(colorizeBuf);
+   return ConsolePrint(colorizeBuf)?true:false;
 }
 
 template<size_t _ColorizeBufSz>

--- a/src/Debugger/Debugger_Parser.cpp
+++ b/src/Debugger/Debugger_Parser.cpp
@@ -113,7 +113,10 @@ int _Arg_1( LPTSTR pName )
 	}
 	else
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 		_tcsncpy( g_aArgs[1].sArg, pName, MAX_ARG_LEN );
+#pragma GCC diagnostic pop
 	}
 	return 1;
 }
@@ -314,7 +317,10 @@ int	ArgsGet ( char * pInput )
 				//if (iTokenSrc == TOKEN_QUOTE_DOUBLE)
 				//	nLen = nBuf;
 				nLen = MIN( nBuf, MAX_ARG_LEN ); // NOTE: see Arg_t.sArg[] // GH#481
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 				_tcsncpy( pArg->sArg, pSrc, nLen );
+#pragma GCC diagnostic pop
 				pArg->sArg[ nLen ] = 0;
 				pArg->nArgLen      = nLen;
 				pArg->eToken       = iTokenSrc;

--- a/src/Debugger/Util_MemoryTextFile.cpp
+++ b/src/Debugger/Util_MemoryTextFile.cpp
@@ -43,7 +43,7 @@ bool MemoryTextFile_t::Read( const std::string & pFileName )
 		m_vBuffer.insert( m_vBuffer.begin(), nSize+1, 0 );
 
 		char *pBuffer = & m_vBuffer.at(0);
-		fread((void*)pBuffer, nSize, 1, hFile);
+		bStatus=(fread((void*)pBuffer, nSize, 1, hFile)>0?true:false);
 		fclose(hFile);
 
 		m_bDirty = true;

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -503,7 +503,7 @@ int DiskInsert(int drive, LPCTSTR imageFileName, bool writeProtected, bool creat
   int error = ImageOpen(tmp, &fptr->imagehandle, &fptr->writeProtected, createIfNecessary);
   if (error == IMAGE_ERROR_NONE) {
     tmp = GetImageTitle(imageFileName, fptr);
-    snprintf(s_title, MAX_DISK_IMAGE_NAME + 32, "%s - %s", g_pAppTitle, tmp);
+    snprintf(s_title, MAX_DISK_IMAGE_NAME + 32, "%.*s - %.*s", int(strlen(g_pAppTitle)), g_pAppTitle, int(strlen(tmp)), tmp);
     if (drive == 0) {
       SDL_WM_SetCaption(s_title, g_pAppTitle);// change caption just for drive 0 (leading)
     }
@@ -629,9 +629,9 @@ void DiskSelectImage(int drive, LPSTR pszFilename)
 
       } else {
         if (strcmp(fullPath, "/")) {
-          snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename); // next dir
+          snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // next dir
         } else {
-          snprintf(tempPath, MAX_PATH, "/%s", filename);
+          snprintf(tempPath, MAX_PATH, "/%.*s", int(strlen(filename)), filename);
         }
         strcpy(fullPath, tempPath);  // got ot anew
         dirdx = fileIndex; // store it
@@ -643,7 +643,7 @@ void DiskSelectImage(int drive, LPSTR pszFilename)
   strcpy(g_sCurrentDir, fullPath);
   RegSaveString(TEXT("Preferences"), REGVALUE_PREF_START_DIR, 1, g_sCurrentDir); // Save it
 
-  snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename); // Next dir
+  snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // Next dir
   strcpy(fullPath, tempPath); // Got ot anew
 
   int error = DiskInsert(drive, fullPath, 0, 1);
@@ -713,10 +713,10 @@ void Disk_FTP_SelectImage(int drive)  // select a disk image using FTP
         fileIndex = dirdx;  // restore
       } else {
         if (strcmp(fullPath, "/")) {
-          snprintf(tempPath, MAX_PATH, "%s%s/", fullPath, filename); // next dir
+          snprintf(tempPath, MAX_PATH, "%.*s%.*s/", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // next dir
         }
         else {
-          snprintf(tempPath, MAX_PATH, "/%s/", filename);
+          snprintf(tempPath, MAX_PATH, "/%.*s/", int(strlen(filename)), filename);
         }
         strcpy(fullPath, tempPath);  // got ot anew
         dirdx = fileIndex; // store it
@@ -728,10 +728,10 @@ void Disk_FTP_SelectImage(int drive)  // select a disk image using FTP
   strcpy(g_sFTPServer, fullPath);
   RegSaveString(TEXT("Preferences"), REGVALUE_FTP_DIR, 1, g_sFTPServer);// save it
 
-  snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename);
+  snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename);
   strcpy(fullPath, tempPath); // fullPath - full path to file on FTP server
 
-  snprintf(tempPath, MAX_PATH, "%s/%s", g_sFTPLocalDir, filename); // local path for file
+  snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(g_sFTPLocalDir)), g_sFTPLocalDir, int(strlen(filename)), filename); // local path for file
 
   int error;
 
@@ -835,7 +835,7 @@ bool DiskDriveSwap()
   memcpy(&g_aFloppyDisk[0], &g_aFloppyDisk[1], sizeof(Disk_t));
   memcpy(&g_aFloppyDisk[1], &temp, sizeof(Disk_t));
   // change title
-  snprintf(s_title, MAX_DISK_IMAGE_NAME + 32, "%s - %s", g_pAppTitle, g_aFloppyDisk[0].imagename);
+  snprintf(s_title, MAX_DISK_IMAGE_NAME + 32, "%.*s - %.*s", int(strlen(g_pAppTitle)), g_pAppTitle, int(strlen(g_aFloppyDisk[0].imagename)), g_aFloppyDisk[0].imagename);
   SDL_WM_SetCaption(s_title, g_pAppTitle);// change caption just for drive 0 (leading)
 
   FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);

--- a/src/DiskChoose.cpp
+++ b/src/DiskChoose.cpp
@@ -152,6 +152,8 @@ bool get_sorted_directory(char *incoming_dir, List<char> &files, List<char> &siz
       strcpy(tmp, list[index]->d_name);
       files.Add(tmp);
       tmp = new char[10];  // 1400000KB
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
       if (1000 > fsize) {   // Kilo
         snprintf(tmp, 9, "%4dK", fsize);
       } else if (1000000 > fsize) {   // Mega
@@ -159,6 +161,7 @@ bool get_sorted_directory(char *incoming_dir, List<char> &files, List<char> &siz
       } else {  // Giga
         snprintf(tmp, 9, "%4dG", (int) (fsize / 1000000));
       }
+#pragma GCC diagnostic pop
       sizes.Add(tmp);  // add corresponding file size to list
     }
   }

--- a/src/DiskFTP.cpp
+++ b/src/DiskFTP.cpp
@@ -86,7 +86,7 @@ bool ChooseAnImageFTP(int sx, int sy, char *ftp_dir, int slot, char **filename, 
   }
   char tmpstr[512];
   char ftpdirpath[MAX_PATH];
-  snprintf(ftpdirpath, MAX_PATH, "%s/%s%s", g_sFTPLocalDir, g_sFTPDirListing, md5str(ftp_dir)); // get path for FTP dir listing
+  snprintf(ftpdirpath, MAX_PATH, "%.*s/%.*s%.*s", int(strlen(g_sFTPLocalDir)), g_sFTPLocalDir, int(strlen(g_sFTPLocalDir)), g_sFTPDirListing, int(strlen(md5str(ftp_dir))), md5str(ftp_dir)); // get path for FTP dir listing
 
   List<char> files;    // our files
   List<char> sizes;    // and their sizes (or 'dir' for directories)

--- a/src/DiskImage.cpp
+++ b/src/DiskImage.cpp
@@ -742,7 +742,12 @@ int ImageOpen(LPCTSTR imagefilename, HIMAGE *hDiskImage_, bool *pWriteProtected_
 
   #define _MAX_EXT  5
   char ext[_MAX_EXT];
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
   _tcsncpy(ext, imagefileext, _MAX_EXT);
+#pragma GCC diagnostic pop
+
   CharLowerBuff(ext, _tcslen(ext));
 
   unsigned int size = GetFileSize(file, NULL);
@@ -809,7 +814,10 @@ int ImageOpen(LPCTSTR imagefilename, HIMAGE *hDiskImage_, bool *pWriteProtected_
     if (*hDiskImage_) {
       ZeroMemory(*hDiskImage_, sizeof(imageinforec));
       // Do this in DiskInsert
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
       _tcsncpy(((imageinfoptr) *hDiskImage_)->filename, imagefilename, MAX_PATH);
+#pragma GCC diagnostic pop
       ((imageinfoptr) *hDiskImage_)->format = format;
       ((imageinfoptr) *hDiskImage_)->file = file;
       ((imageinfoptr) *hDiskImage_)->offset = pImage - view;

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -263,7 +263,7 @@ void FrameQuickState(int num, int mod)
 {
   // quick load or save state with number num, if Shift is pressed, state is being saved, otherwise - being loaded
   char fpath[MAX_PATH];
-  snprintf(fpath, MAX_PATH, "%s/SaveState%d.aws", g_sSaveStateDir, num); // prepare file name
+  snprintf(fpath, MAX_PATH, "%.*s/SaveState%d.aws", int(strlen(g_sSaveStateDir)), g_sSaveStateDir, num); // prepare file name
   Snapshot_SetFilename(fpath);  // set it as a working name
   if (mod & KMOD_SHIFT) {
     Snapshot_SaveState();
@@ -525,9 +525,9 @@ bool PSP_SaveStateSelectImage(bool saveit)
         fileIndex = dirdx;  // restore
       } else {
         if (strcmp(fullPath, "/")) {
-          snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename); // next dir
+          snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // next dir
         } else {
-          snprintf(tempPath, MAX_PATH, "/%s", filename);
+          snprintf(tempPath, MAX_PATH, "/%.*s", int(strlen(filename)), filename);
         }
         strcpy(fullPath, tempPath);  // got ot anew
         dirdx = fileIndex; // store it
@@ -540,7 +540,7 @@ bool PSP_SaveStateSelectImage(bool saveit)
 
   backdx = fileIndex; // Store cursor position
 
-  snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename); // Next dir
+  snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // Next dir
   strcpy(fullPath, tempPath); // Got ot anew
 
   Snapshot_SetFilename(fullPath); // Set name for snapshot
@@ -555,11 +555,15 @@ void FrameSaveBMP(void) {
   static int i = 1;  // index
   char bmpName[20];  // file name
 
-  snprintf(bmpName, 20, "linapple%d.bmp", i);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+  snprintf(bmpName, 20, "linapple%7d.bmp", i);
   while (!stat(bmpName, &bufp)) { // Find first absent file
     i++;
-    snprintf(bmpName, 20, "linapple%d.bmp", i);
+    snprintf(bmpName, 20, "linapple%7d.bmp", i);
   }
+#pragma GCC diagnostic pop
+
   SDL_SaveBMP(screen, bmpName);  // Save file using SDL inner function
   printf("File %s saved!\n", bmpName);
   i++;

--- a/src/Harddisk.cpp
+++ b/src/Harddisk.cpp
@@ -165,6 +165,8 @@ void HD_ResetStatus(void)
 
 static void GetImageTitle(LPCTSTR imageFileName, PHDD pHardDrive)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
   char imagetitle[128];
   LPCTSTR startpos = imageFileName;
 
@@ -199,6 +201,7 @@ static void GetImageTitle(LPCTSTR imageFileName, PHDD pHardDrive)
 
   _tcsncpy(pHardDrive->hd_imagename, imagetitle, 15);
   pHardDrive->hd_imagename[15] = 0;
+#pragma GCC diagnostic pop
 }
 
 static void NotifyInvalidImage(char *filename)
@@ -354,9 +357,9 @@ void HD_FTP_Select(int nDrive)
         fileIndex = dirdx;  // restore
       } else {
         if (strcmp(fullPath, "/")) {
-          snprintf(tempPath, MAX_PATH, "%s%s/", fullPath, filename); // next dir
+          snprintf(tempPath, MAX_PATH, "%.*s%.*s/", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // next dir
         } else {
-          snprintf(tempPath, MAX_PATH, "/%s/", filename);
+          snprintf(tempPath, MAX_PATH, "/%.*s/", int(strlen(filename)), filename);
         }
         strcpy(fullPath, tempPath);  // got ot anew
         printf("HD_FTP_Select: we build %s\n", tempPath);
@@ -369,10 +372,10 @@ void HD_FTP_Select(int nDrive)
   strcpy(g_sFTPServerHDD, fullPath);
   RegSaveString(TEXT("Preferences"), REGVALUE_FTP_HDD_DIR, 1, g_sFTPServerHDD);// save it
 
-  snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename);
+  snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename);
   strcpy(fullPath, tempPath); // fullPath - full path to file on FTP server
 
-  snprintf(tempPath, MAX_PATH, "%s/%s", g_sFTPLocalDir, filename); // local path for file
+  snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(g_sFTPLocalDir)), g_sFTPLocalDir, int(strlen(filename)), filename); // local path for file
 
   int error = ftp_get(fullPath, tempPath);
   if (!error) {
@@ -422,10 +425,10 @@ void HD_Select(int nDrive)
         fileIndex = dirdx;  // restore
       } else {
         if (strcmp(fullPath, "/")) {
-          snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename); // next dir
+          snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // next dir
         }
         else {
-          snprintf(tempPath, MAX_PATH, "/%s", filename);
+          snprintf(tempPath, MAX_PATH, "/%.*s", int(strlen(filename)), filename);
         }
         strcpy(fullPath, tempPath);  // got ot anew
         dirdx = fileIndex; // store it
@@ -437,7 +440,7 @@ void HD_Select(int nDrive)
   strcpy(g_sHDDDir, fullPath);
   RegSaveString(TEXT("Preferences"), REGVALUE_PREF_HDD_START_DIR, 1, g_sHDDDir); // Save it
 
-  snprintf(tempPath, MAX_PATH, "%s/%s", fullPath, filename); // Next dir
+  snprintf(tempPath, MAX_PATH, "%.*s/%.*s", int(strlen(fullPath)), fullPath, int(strlen(filename)), filename); // Next dir
   strcpy(fullPath, tempPath);  // Got ot anew
 
   // in future: save file name in registry for future fetching

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -121,8 +121,7 @@ static bool setbutton[3] = {0, 0, 0}; // Used when a mouse button is pressed/rel
 static int xpos[2] = {PDL_CENTRAL, PDL_CENTRAL};
 static int ypos[2] = {PDL_CENTRAL, PDL_CENTRAL};
 
-static unsigned __int64
-g_nJoyCntrResetCycle = 0;  // Abs cycle that joystick counters were reset
+static UINT64 g_nJoyCntrResetCycle = 0;  // Abs cycle that joystick counters were reset
 
 static int g_nPdlTrimX = 0;
 static int g_nPdlTrimY = 0;
@@ -619,8 +618,7 @@ unsigned char JoyReadPosition(unsigned short programcounter, unsigned short addr
   //if(nPdlPos >= 255)
   //  nPdlPos = 280;
 
-  bool nPdlCntrActive = g_nCumulativeCycles <= (g_nJoyCntrResetCycle + (unsigned
-  __int64) ((double) nPdlPos * PDL_CNTR_INTERVAL));
+  bool nPdlCntrActive = (g_nCumulativeCycles <= (g_nJoyCntrResetCycle + (UINT64) ((double) nPdlPos * PDL_CNTR_INTERVAL)));
 
   return MemReadFloatingBus(nPdlCntrActive, nCyclesLeft);
 }

--- a/src/Mockingboard.cpp
+++ b/src/Mockingboard.cpp
@@ -78,8 +78,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* Needs adaptation for SDL and POSIX */
 
 #define LOG_SSI263 0
-#define UINT64 unsigned __int64
-
 
 #include "stdafx.h"
 
@@ -142,8 +140,7 @@ static SY6522_AY8910 g_MB[NUM_AY8910];
 // Timer vars
 static ULONG g_n6522TimerPeriod = 0;
 static USHORT g_nMBTimerDevice = 0;  // SY6522 device# which is generating timer IRQ
-static unsigned __int64
-g_uLastCumulativeCycles = 0;
+static UINT64 g_uLastCumulativeCycles = 0;
 
 #ifdef MB_SPEECH
 // SSI263 vars:
@@ -156,8 +153,7 @@ static HANDLE g_hThread = NULL;
 
 static short *ppAYVoiceBuffer[NUM_VOICES] = {0};
 
-static unsigned __int64
-g_nMB_InActiveCycleCount = 0;
+static UINT64 g_nMB_InActiveCycleCount = 0;
 static bool g_bMB_RegAccessedFlag = false;
 static bool g_bMB_Active = true;
 static bool g_bMBAvailable = false;
@@ -688,8 +684,7 @@ void MB_Update() {
   if (!g_bMB_RegAccessedFlag) {
     if (!g_nMB_InActiveCycleCount) {
       g_nMB_InActiveCycleCount = g_nCumulativeCycles;
-    } else if (g_nCumulativeCycles - g_nMB_InActiveCycleCount > (unsigned
-      __int64)g_fCurrentCLK6502 / 10) {
+    } else if (g_nCumulativeCycles - g_nMB_InActiveCycleCount > (UINT64)g_fCurrentCLK6502 / 10) {
       // After 0.1 sec of Apple time, assume MB is not active
       g_bMB_Active = false;
     }

--- a/src/Riff.cpp
+++ b/src/Riff.cpp
@@ -28,6 +28,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Adaptation for SDL and POSIX (l) by beom beotiger, Nov-Dec 2007 */
 
+#include <inttypes.h>
+#include <stdint.h>
 #include "wincompat.h"
 #include "Riff.h"
 #include "wwrapper.h"

--- a/src/Speaker.cpp
+++ b/src/Speaker.cpp
@@ -71,10 +71,8 @@ unsigned int soundtype = SOUND_WAVE; //default
 double g_fClksPerSpkrSample;    // Setup in SetClksPerSpkrSample()
 
 // Globals
-static unsigned __int64
-g_nSpkrQuietCycleCount = 0;
-static unsigned __int64
-g_nSpkrLastCycle = 0;
+static UINT64 g_nSpkrQuietCycleCount = 0;
+static UINT64 g_nSpkrLastCycle = 0;
 static bool g_bSpkrToggleFlag = false;
 
 static bool g_bSpkrAvailable = false;
@@ -270,8 +268,7 @@ void SpkrUpdate(unsigned int totalcycles) {
   if (!g_bSpkrToggleFlag) {
     if (!g_nSpkrQuietCycleCount) {
       g_nSpkrQuietCycleCount = g_nCumulativeCycles;
-    } else if (g_nCumulativeCycles - g_nSpkrQuietCycleCount > (unsigned
-      __int64)g_fCurrentCLK6502 / 5)
+    } else if (g_nCumulativeCycles - g_nSpkrQuietCycleCount > (UINT64)g_fCurrentCLK6502 / 5)
     {
       // After 0.2 sec of Apple time, deactivate spkr voice
       // . This allows emulator to auto-switch to full-speed g_nAppMode for fast disk access

--- a/src/wwrapper.cpp
+++ b/src/wwrapper.cpp
@@ -3,6 +3,7 @@
  *  by beom beotiger, Nov 2007AD
 */
 
+#include "stdafx.h"
 #include "wwrapper.h"
 
 unsigned int SetFilePointer(HANDLE hFile, int lDistanceToMove, PLONG lpDistanceToMoveHigh, unsigned int dwMoveMethod)


### PR DESCRIPTION
Based on conversations, this should fix the changes that 6aa645a wrought, and allow linapple to once again compile from source and run correctly.

I have tested this on  arm32 (armv6l, raspbian)   and  amd64(kubuntu 21.04),  and while there are still warnings about truncations due to size conversions, the majority of those are string-based, and not addressed here.

The fact that this semi-reverted, fixed-up code with c99 types works in both places says much for using bit-accurate typedefs in variables, so that platform changes aren't impacted.

