### PR TITLE
Cleanup of Clang-Tidy warnings in Applewin

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-bool-pointer-implicit-conversion,readability-implicit-bool-cast,readability-simplify-boolean-expr,modernize-use-bool-literals'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@
 #### Debian / Ubuntu / RetroPie
 
 ```bash
-sudo apt-get install git libzip-dev libsdl1.2-dev libsdl-image1.2-dev libcurl4-openssl-dev zlib1g-dev imagemagick
+sudo apt-get install git libzip-dev libsdl1.2-dev libsdl-image1.2-dev libcurl4-openssl-dev zlib1g-dev libtime-parsedate-perl imagemagick
 ```
 
 #### Fedora / RHEL / CentOS

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,9 @@ $(BUILDDIR)/%.$(XPMEXT): $(RESDIR)/%.$(IMGEXT)
 $(TARGETDIR)/%.$(SYMEXT): $(RESDIR)/%.$(SYMEXT)
 	cp $< $@
 
+ctidy: resources
+	clang-tidy $(SRCDIR)/*.$(SRCEXT) $(SRCDIR)/Debugger/*.$(SRCEXT) -- $(CFLAGS) $(INC) 2>&1 | tee clang-tidy.log
+
 install: all
 	install -D --target-directory "$(DESTDIR)/$(BINDIR)" build/$(BINDIR)/$(TARGET)
 	install -D --target-directory "$(DESTDIR)/$(DATADIR)" build/$(DATADIR)/Master.dsk

--- a/inc/AppleWin.h
+++ b/inc/AppleWin.h
@@ -8,9 +8,6 @@
 
 #define FTP_SEPARATOR  TEXT('/')
 
-// let it be our second version!
-#define LINAPPLE_VERSION  2
-
 #include <curl/curl.h>
 
 extern char *g_pAppTitle;


### PR DESCRIPTION
This resolves some warning provided by Clang-Tidy. I only targeted Applwin.(c/h) in this commit. I have tested the code compiles and could play Cave of Time.

Primarily changes are
* `bool`s now use `true` and `false` instead of `1` and `0`.
* Use the cpp `time` in place of the c `time.h`.
* Replace use of `NULL` with `nullptr`.

There are other changes than this. This should definitely be inspected by someone with more cpp experience than me who can evaluate and test the likely impacts of this in more detail. Until then I'm leaving this as a draft for review. If this looks good I'll take the time to update the other files.