### PR TITLE
Bug fix: can now compile on 32-bit platforms

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -496,7 +496,7 @@ void FrameDispatchMessage(SDL_Event *e) {// process given SDL event
 
 bool PSP_SaveStateSelectImage(bool saveit)
 {
-  static uintmax_t fileIndex = 0;    // file index will be remembered for current dir
+  static size_t fileIndex = 0;    // file index will be remembered for current dir
   static int backdx = 0;  // reserve
   static int dirdx = 0;  // reserve for dirs
 


### PR DESCRIPTION
This fixes issue #182.  The cause is that on (some) 32-bit platforms, `uintmax_t` and `size_t` have different sizes.  The previous merge has mixed these up.