### PR TITLE
Eject support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,12 @@ git clone https://github.com/linappleii/linapple.git
 cd linapple
 make
 ```
+
+to enable rewrite user settings
+```bash
+make -e REGISTRY_WRITEABLE=1
+```
+
 For a faster compilation, you can add an option "-jX", where "X" is the number of threads of your CPU. For example, *AMD Ryzen 5 2600* has 6 cores, but 12 threads:
 ```bash
 make -j12

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # https://www.gnu.org/prep/standards/html_node/Standard-Targets.html
 
 PACKAGE     := linapple
-VERSION     := 2.2.1
+VERSION     := 2.3.0
 
 #Compiler and Linker
 CC          := g++
@@ -62,6 +62,10 @@ endif
 
 ifdef DEBUG
 CFLAGS := -O0 -ggdb -ansi -c -finstrument-functions -std=c++11 -Wno-write-strings -Werror
+endif
+
+ifdef REGISTRY_WRITEABLE
+CFLAGS += "-DREGISTRY_WRITEABLE=1"
 endif
 
 CFLAGS += -DASSET_DIR=\"$(DATADIR)\" -DVERSIONSTRING=\"$(VERSION)\"
@@ -178,6 +182,7 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
 
 $(BUILDDIR)/%.$(XPMEXT): $(RESDIR)/%.$(IMGEXT)
 	convert -flatten "$<" "$@"
+	@sed -i 's/static const char/static char/g' "$@"
 	@sed -i 's/$(notdir $(basename $@))\[\]/$(notdir $(basename $@))_xpm[]/g' "$@"
 
 $(TARGETDIR)/%.$(SYMEXT): $(RESDIR)/%.$(SYMEXT)

--- a/README.md
+++ b/README.md
@@ -58,11 +58,23 @@ released by pressing any function key.
 | F1             | Show help screen.                                                |
 | Ctrl+F2        | Cold reboot, i.e. power off and back on.                         |
 | Shift+F2       | Reload configuration file and cold reboot.                       |
-| F3             | Load disk image for drive 1.                                     |
-| F4             | Load disk image for drive 2.                                     |
-| Shift+F3       | Attach hard disk image to slot 7.                                |
-| Shift+F4       | Attach hard disk image to slot 7.                                |
+| Ctrl+F10       | Hot Reset (Control+Reset)                                        |
+| F12            | Quit.                                                            |
+| -------------- | -----------------------------------------------------------------|
+| F3             | Load disk image to slot 6 drive 1.                               |
+| F4             | Load disk image to slot 6 drive 2.                               |
 | F5             | Swap drives for slot 6.                                          |
+| Alt+F3         | Load disk image to slot 6 drive 1 from FTP server.               |
+| Alt+F4         | Load disk image to slot 6 drive 2 from FTP server.               |
+| Shift+F3       | Attach hard disk image to slot 7 drive 1.                        |
+| Shift+F4       | Attach hard disk image to slot 7 drive 2.                        |
+| Alt+Shift+F3   | Attach hard disk image to slot 7 from FTP server.                |
+| Alt+Shift+F4   | Attach hard disk image to slot 7 from FTP server.                |
+| Ctrl+F3        | Eject disk image to slot 6 drive 1.                              |
+| Ctrl+F4        | Eject disk image to slot 6 drive 2.                              |
+| Ctrl+Shift+F3  | Eject hard disk image to slot 7 drive 1.                         |
+| Ctrl+Shift+F4  | Eject hard disk image to slot 7 drive 2.                         |
+| -------------- | -----------------------------------------------------------------|
 | F6             | Toggle fullscreen mode. See Warning below.                       |
 | Shift+F6       | Toggle character set (keyboard/video ROM rocker switch for       |
 |                | Apple IIe/enhanced with international keyboards/video ROMs)      |
@@ -70,17 +82,19 @@ released by pressing any function key.
 | F8             | Save screenshot as a bitmap.                                     |
 | Shift+F8       | Save runtime changes to configuration to the configuration file. |
 | F9             | Cycle through video modes.                                       |
+| Shift+F9       | Budget video, for smoother music/audio.                          |
 | F10            | Load snapshot file.                                              |
 | F11            | Save snapshot file.                                              |
-| F12            | Quit.                                                            |
 | Ctrl+0-9       | Load snapshot `n`.                                               |
 | Ctrl+Shift+0-9 | Save snapshot `n`.                                               |
+| -------------- | -----------------------------------------------------------------|
 | Pause          | Pause/resume emulation.                                          |
 | Scroll Lock    | Toggle full speed emulation.                                     |
 | Numpad +       | Increase emulation speed.                                        |
 | Numpad -       | Decrease emulation speed.                                        |
 | Numpad *       | Reset emulation speed.                                           |
 | RtCtrl+Numpad  | Adjust pdl TrimX (4, 6) or TrimY (2, 8)                          |
+| -------------- | -----------------------------------------------------------------|
 
 **Warning**: Fullscreen mode does not properly exit in multi-monitor
 setups.  (This is a bug in SDL 1.2.)

--- a/inc/Harddisk.h
+++ b/inc/Harddisk.h
@@ -10,6 +10,8 @@ LPCTSTR HD_GetFullName(int drive);
 
 void HD_Load_Rom(LPBYTE pCxRomPeripheral, unsigned int uSlot);
 
+void HD_Eject(const int iDrive);
+
 void HD_Cleanup();
 
 bool HD_InsertDisk2(int nDrive, LPCTSTR pszFilename);

--- a/inc/Registry.h
+++ b/inc/Registry.h
@@ -12,5 +12,7 @@ void RegSaveString(LPCTSTR, LPCTSTR, bool, LPCTSTR);
 void RegSaveValue(LPCTSTR, LPCTSTR, bool, unsigned int);
 void RegSaveBool(LPCTSTR, LPCTSTR, bool, bool);
 
+void RegConfPath(const char *);
+
 char *php_trim(char *c, int len);  // trimming string like PHP function trim does!
 

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -885,6 +885,7 @@ void LoadAllConfigurations(const char *userSpecifiedFilename)
         exit(EXIT_SUCCESS);
       }
     }
+    RegConfPath(userSpecifiedFilename);
     LoadConfiguration();
     return;
   }
@@ -954,6 +955,8 @@ void LoadAllConfigurations(const char *userSpecifiedFilename)
   // code. Doing so could affect all other users. Instead, a super-user should
   // edit the /etc/xdg/linapple/linapple.conf by hand.
   if (lastSuccessfulUserConfig.length() > 0) {
+
+    RegConfPath(lastSuccessfulUserConfig.c_str());
     registry = fopen(lastSuccessfulUserConfig.c_str(), "r+");
     return;
   }
@@ -970,6 +973,8 @@ void LoadAllConfigurations(const char *userSpecifiedFilename)
   std::string userDir(home);
   mkdir(xdgConfigHome.c_str(), 0700);
   mkdir((xdgConfigHome + "/linapple").c_str(), 0700);
+
+  RegConfPath((xdgConfigHome + "/linapple/linapple.conf").c_str());
   registry = fopen((xdgConfigHome + "/linapple/linapple.conf").c_str(), "w+");
 }
 

--- a/src/Applewin.cpp
+++ b/src/Applewin.cpp
@@ -408,7 +408,7 @@ bool ValidateDirectory(char *dir)
       }
     }
   }
-  printf("%s is dir? %d\n", dir, ret);
+  printf(" ---> %s is dir? %d\n", dir, ret);
   return ret;
 }
 

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -374,6 +374,11 @@ void DiskEject(const int iDrive)
 {
   if (IsDriveValid(iDrive)) {
     RemoveDisk(iDrive);
+    if (iDrive == 0) {
+      RegSaveString(TEXT("Preferences"), REGVALUE_DISK_IMAGE1, 1, "");
+    } else {
+      RegSaveString(TEXT("Preferences"), REGVALUE_DISK_IMAGE2, 1, "");
+    }
   }
 }
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -604,6 +604,17 @@ void ProcessButtonClick(int button, int mod)
     case BTN_DRIVE1:
     case BTN_DRIVE2:
       JoyReset();
+      if (mod & KMOD_CTRL) {
+        if (mod & KMOD_SHIFT) {
+          printf("HDD  Eject Drive #%d\n", button - BTN_DRIVE1);
+          HD_Eject(button - BTN_DRIVE1);
+        } else {
+          printf("Disk Eject Drive #%d\n", button - BTN_DRIVE1);
+          DiskEject(button - BTN_DRIVE1);
+        }
+        break;
+      }
+
       if (mod & KMOD_SHIFT) {
         if (mod & KMOD_ALT) {
           HD_FTP_Select(button - BTN_DRIVE1);// select HDV image through FTP

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -606,10 +606,10 @@ void ProcessButtonClick(int button, int mod)
       JoyReset();
       if (mod & KMOD_CTRL) {
         if (mod & KMOD_SHIFT) {
-          printf("HDD  Eject Drive #%d\n", button - BTN_DRIVE1);
+          printf("HDD  Eject Drive #%d\n", (button - BTN_DRIVE1) + 1);
           HD_Eject(button - BTN_DRIVE1);
         } else {
-          printf("Disk Eject Drive #%d\n", button - BTN_DRIVE1);
+          printf("Disk Eject Drive #%d\n", (button - BTN_DRIVE1) + 1);
           DiskEject(button - BTN_DRIVE1);
         }
         break;

--- a/src/Harddisk.cpp
+++ b/src/Harddisk.cpp
@@ -290,6 +290,17 @@ void HD_Cleanup() {
   }
 }
 
+void HD_Eject(const int iDrive) {
+  if (g_HardDrive[iDrive].hd_imageloaded) {
+    HD_CleanupDrive(iDrive);
+    if (iDrive == 0) {
+      RegSaveString(TEXT("Preferences"), REGVALUE_HDD_IMAGE1, 1, "");
+    } else {
+      RegSaveString(TEXT("Preferences"), REGVALUE_HDD_IMAGE2, 1, "");
+    }
+  }
+}
+
 // pszFilename is not qualified with path
 bool HD_InsertDisk2(int nDrive, LPCTSTR pszFilename) {
   if (*pszFilename == 0x00) {

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -30,7 +30,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "stdafx.h"
 
+#define PATH_MAX 4096
+
 FILE *registry;
+
+char confPath[PATH_MAX];
 
 // the following 3 functions are from PHP 5.0 with Zend engine sources
 // I'll tell, folks, PHP group is just great! -- bb
@@ -87,6 +91,10 @@ char *php_trim(char *c, int len) {
   return estrndup(c, len); // from c to c+len
 }
 
+void RegConfPath(const char * filename) {
+  strncpy(confPath, filename, MAX_PATH);
+  printf("conf = %s\n", confPath);
+}
 
 bool ReturnKeyValue(char *line, char **key, char **value) {
   // line should be:  some key  =  some value
@@ -165,6 +173,7 @@ bool RegLoadValue(LPCTSTR section, LPCTSTR key, bool peruser, unsigned int *valu
 }
 
 void RegSaveKeyValue(char *NKey, char *NValue) {
+  printf("update conf = %s\n", confPath);
   #ifdef REGISTRY_WRITEABLE
   char MyStr[BUFSIZE];
   char line[BUFSIZE];
@@ -195,7 +204,7 @@ void RegSaveKeyValue(char *NKey, char *NValue) {
   fflush(tempf);
   fseek(tempf, 0, SEEK_SET);
   // FIXME if you re-enable this code, you will need to call config.GetRegistryPath() here instead!
-  registry = fopen(REGISTRY, "w+t");  // erase if been
+  registry = fopen(confPath, "w+t");  // erase if been
   while(fgets(line, BUFSIZE, tempf)) {
     fputs(line, registry);
   }

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -30,11 +30,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "stdafx.h"
 
-#define PATH_MAX 4096
-
 FILE *registry;
 
-char confPath[PATH_MAX];
+char confPath[MAX_PATH];
 
 // the following 3 functions are from PHP 5.0 with Zend engine sources
 // I'll tell, folks, PHP group is just great! -- bb
@@ -173,6 +171,8 @@ bool RegLoadValue(LPCTSTR section, LPCTSTR key, bool peruser, unsigned int *valu
 }
 
 void RegSaveKeyValue(char *NKey, char *NValue) {
+  if (strlen(confPath) <= 0) return;
+
   printf("update conf = %s\n", confPath);
   #ifdef REGISTRY_WRITEABLE
   char MyStr[BUFSIZE];


### PR DESCRIPTION
Thanks [timriker](https://github.com/timriker) #190 

++1. Update Readme.
++2. Eject  floppy or harddrive.
++3. Update Registry for support save config in runtime. (optional) from **make -e REGISTRY_WRITEABLE=1**

~~~text
| -------------- | -----------------------------------------------------------------|
| F3             | Load disk image to slot 6 drive 1.                               |
| F4             | Load disk image to slot 6 drive 2.                               |
| F5             | Swap drives for slot 6.                                          |
| Alt+F3         | Load disk image to slot 6 drive 1 from FTP server.               |
| Alt+F4         | Load disk image to slot 6 drive 2 from FTP server.               |
| Shift+F3       | Attach hard disk image to slot 7 drive 1.                        |
| Shift+F4       | Attach hard disk image to slot 7 drive 2.                        |
| Alt+Shift+F3   | Attach hard disk image to slot 7 from FTP server.                |
| Alt+Shift+F4   | Attach hard disk image to slot 7 from FTP server.                |
| Ctrl+F3        | Eject disk image to slot 6 drive 1.                              |
| Ctrl+F4        | Eject disk image to slot 6 drive 2.                              |
| Ctrl+Shift+F3  | Eject hard disk image to slot 7 drive 1.                         |
| Ctrl+Shift+F4  | Eject hard disk image to slot 7 drive 2.                         |
| -------------- | -----------------------------------------------------------------|
~~~