### PR TITLE
Fix build with GCC 13

### DIFF
--- a/inc/file_entry.h
+++ b/inc/file_entry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdint.h>
 #include <string>
 


### PR DESCRIPTION
GCC 13 now requires some standard library headers to be included explicitly. Specifically we need `<cstdint>` for `uintmax_t`.

See https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes