### PR TITLE
Super Serial Card receive char and proper rxbuf fixes

### DIFF
--- a/inc/SerialComms.h
+++ b/inc/SerialComms.h
@@ -3,6 +3,7 @@
 #include <pthread.h>
 
 extern class CSuperSerialCard sg_SSC;
+class DataRing;
 
 enum {
   COMMEVT_WAIT = 0, COMMEVT_ACK, COMMEVT_TERM, COMMEVT_MAX
@@ -43,9 +44,7 @@ typedef struct {
 class CSuperSerialCard {
 public:
   CSuperSerialCard();
-
-  virtual ~CSuperSerialCard() {
-  }
+  virtual ~CSuperSerialCard();
 
   void CommInitialize(LPBYTE pCxRomPeripheral, unsigned int uSlot);
 
@@ -129,8 +128,7 @@ private:
   int m_hCommHandle;  // file for communication with COM
   unsigned int m_dwCommInactivity;
 
-  unsigned char m_RecvBuffer[uRecvBufferSize];  // NB: More work required if >1 is used
-  volatile unsigned int m_vRecvBytes;
+	DataRing *rxbuf = nullptr;
 
   bool m_bTxIrqEnabled;
   bool m_bRxIrqEnabled;

--- a/inc/file_entry.h
+++ b/inc/file_entry.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 

--- a/inc/stdafx.h
+++ b/inc/stdafx.h
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <time.h>
 #include <inttypes.h>
-#include <stdint.h>
+#include <cstdint>
 
 #ifndef _WIN32
 #  include "wincompat.h"

--- a/src/AY8910.cpp
+++ b/src/AY8910.cpp
@@ -29,7 +29,7 @@
 //
 
 #include <inttypes.h>
-#include <stdint.h>
+#include <cstdint>
 #include "wincompat.h"
 #include <stdio.h>
 #include <string.h>

--- a/src/Riff.cpp
+++ b/src/Riff.cpp
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* Adaptation for SDL and POSIX (l) by beom beotiger, Nov-Dec 2007 */
 
 #include <inttypes.h>
-#include <stdint.h>
+#include <cstdint>
 #include "wincompat.h"
 #include "Riff.h"
 #include "wwrapper.h"

--- a/src/dataring.cpp
+++ b/src/dataring.cpp
@@ -1,0 +1,498 @@
+
+#include <stdio.h>
+#include <cassert>
+#include <stdlib.h>
+#include <stdint.h>
+#include <memory.h>
+#include "dataring.h"
+
+#define DATARING_DEBUG
+//#define DATARING_DEBUG2		// requires libkaty
+
+#ifdef DATARING_DEBUG
+	#define debug(...)	do {	\
+	printf(__VA_ARGS__);	\
+	printf("\n");	\
+} while(0)
+#else
+	#define debug(...)	do { } while(0)
+#endif
+
+#define error(...)	do {	\
+	printf(__VA_ARGS__);	\
+	printf("\n");	\
+} while(0)
+
+DataRing::DataRing(int ring_initial_size) {
+	fHead = fTail = 0;
+	fBufferBase = NULL;
+	fBuffer = NULL;
+	fPreBuffer = NULL;
+	fPostBuffer = NULL;
+	fRingSize = 0;
+
+	if (ring_initial_size)
+		SetRingSize(ring_initial_size);
+}
+
+DataRing::~DataRing() {
+	free(fBufferBase);
+	fBufferBase = NULL;
+	fBuffer = NULL;
+	fPreBuffer = fPostBuffer = NULL;
+}
+
+void DataRing::SetRingSize(int newSize) {
+	// need one extra byte because we must always leave at least one byte
+	// unused to tell the difference between an empty and full buffer
+	newSize++;
+
+	if (newSize != fRingSize || fBuffer == NULL) {
+		fHead = fTail = 0;
+
+		// we'll allocate space before and after the ring for when we need to
+		// temporarily reassemble wrapped chunks to make them contiguous.
+		// worst case amount we'll need to copy is half the size of the ring
+		// buffer. think of it like a literal circular paper tape that you're
+		// cutting to extend into a solid line. the most you'll ever need to
+		// cut is half the circle, because any longer than that and you'd just
+		// cut the other end.
+		//
+		// note: factored out the +/-1's in "(((newSize - 1) + 1) & ~1) / 2"
+		// 		(newSize - 1)		remove the byte we added earlier for full/empty disambiguation
+		//		+1 & ~1				round up to nearest even integer before division / 2
+		//		>> 1				will at most need half that much
+		fReassemblySize = (newSize & ~1) >> 1;
+		fRingSize = newSize;
+		fBufTotalSize = fReassemblySize + fRingSize + fReassemblySize;
+
+		// ensure that the main ring buffer ends up word-aligned for speed --
+		// usually, malloc would probably do this for us, but it doesn't know
+		// about our extra reassembly padding, so let's hold it's hand a little
+		int wordAlignPad = 0;
+		int ringBufferOffset = fReassemblySize;
+		if (ringBufferOffset & 3)
+			wordAlignPad = 4 - (ringBufferOffset & 3);
+
+		int bufAllocSize = fBufTotalSize + wordAlignPad;
+
+		debug("setting fRingSize = %d; fReassemblySize = %d",
+				fRingSize, fReassemblySize);
+		debug("fBufTotalSize = %d(%d); wordAlignPad = %d",
+				fBufTotalSize, bufAllocSize, wordAlignPad);
+
+		free(fBufferBase);
+		fBufferBase = (uint8_t *)malloc(bufAllocSize);
+
+		fPreBuffer = fBufferBase + wordAlignPad;
+		fBuffer = fPreBuffer + fReassemblySize;
+		fPostBuffer = fBuffer + fRingSize;
+
+		memset(fPostBuffer, 0xff, fReassemblySize);
+		memset(fBuffer, 0xee, fRingSize);
+		memset(fPreBuffer, 0xff, fReassemblySize);
+
+		// debug markers at boundaries
+		//#ifndef CONFIG_RELEASE
+		//fPreBuffer[0] = 0x10; fPreBuffer[fReassemblySize - 1] = 0x19;
+		//fBuffer[0] = 0x20; fBuffer[fRingSize - 1] = 0x29;
+		//fPostBuffer[0] = 0x30; fPostBuffer[fReassemblySize - 1] = 0x39;
+		//#endif
+	}
+}
+
+void DataRing::Clear() {
+	fHead = fTail;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+int DataRing::Append(const void *datain, int dataLength)
+{
+	const uint8_t *data = (const uint8_t *)datain;
+	if (dataLength <= 0) {
+		error("received invalid dataLength %d", dataLength);
+		return -1;
+	}
+
+	int bytesFree = BytesFree();
+	if (dataLength > bytesFree) {
+		error("attempt to append %d bytes into ring "
+				"when only %d %s available",
+				dataLength, bytesFree,
+				(bytesFree == 1) ? "is" : "are");
+		error("buffer contents looks like:");
+		Dump();
+		return -1;
+	}
+
+	// copy bytes into the buffer, wrapping if necessary
+	// first get how many bytes we can push before we'd reach the end and
+	// have to wrap
+	int bytesToEnd = (fRingSize - fTail);
+	debug("insert %d bytes, bytesToEnd = %d at head %d, tail %d (before insertion)",
+			dataLength, bytesToEnd, fHead, fTail);
+	
+	if (dataLength <= bytesToEnd)
+	{	// normal simple insertion
+		memcpy(fBuffer + fTail, data, dataLength);
+
+		// even though the data isn't wrapped, the tail can still wrap around
+		// in some scenarios (e.g. tail = 1, dataLength = ringSize) so we have
+		// to check. this is because the tail points at the byte AFTER the end;
+		// which makes sense as (head == tail) means empty/0.
+		fTail += dataLength;
+		if (fTail >= fRingSize) fTail -= fRingSize;
+	}
+	else
+	{	// the tail is advanced to a point where we need to put some of the
+		// inserted data at the tail, and the rest should "wrap around" to
+		// the beginning of the ring buffer
+		debug("performing wrapped insertion: %d bytes at tail, %d at start",
+				bytesToEnd, dataLength - bytesToEnd);
+
+		memcpy(fBuffer + fTail, data, bytesToEnd);
+		memcpy(fBuffer, data + bytesToEnd, dataLength - bytesToEnd);
+	
+		// the formula is actually (tail + datalen) % bufferSize, but we
+		// already KNOW it will wrap. so we can do the clamp unconditionally.
+		fTail = (fTail + dataLength) - fRingSize;
+	}
+	
+	debug("added %d bytes; head=%d/tail=%d; now holding %d bytes",
+			dataLength, fHead, fTail, BytesAvail());
+
+	return 0;
+}
+
+int DataRing::Prepend(const void *datain, int dataLength) {
+	const uint8_t *data = (const uint8_t *)datain;
+
+	int bytesFree = BytesFree();
+	if (dataLength > bytesFree) {
+		error("attempt to prepend %d bytes into ring "
+				"when only %d %s available",
+				dataLength, bytesFree,
+				(bytesFree == 1) ? "is" : "are");
+		return -1;
+	}
+
+	debug("Prepending %d bytes", dataLength);
+
+	fHead -= dataLength;
+	if (fHead >= 0)
+	{	// easy case, so just copy it in now that we've "made room"
+		memcpy(fBuffer + fHead, data, dataLength);
+	}
+	else
+	{
+		fHead += fRingSize;		// clamp back in range
+
+		// wrapped case. so we need to copy some bytes to wherever
+		// the NEW head is, and then the rest to the beginning. this actually
+		// works out just like the Append case, except for using the head
+		// instead of tail and the fact that we moved the head first
+		int bytesToEnd = (fRingSize - fHead);
+		debug("got bytesToEnd %d", bytesToEnd);
+		memcpy(fBuffer + fHead, data, bytesToEnd);
+		memcpy(fBuffer, data + bytesToEnd, dataLength - bytesToEnd);
+	}
+
+	return 0;
+}
+
+// moves the head/tail pointers as they should be after a Read().
+// normally done for you but broken out so you can do this separately if you
+// are wanting to "peek" at the data to see if you want it before definitely
+// removing it.
+void DataRing::Commit(int readLen)
+{
+	// remove the requested # of bytes from the buffer
+	fHead += readLen;
+	if (fHead >= fRingSize) fHead -= fRingSize;
+
+	// if the buffer is now empty, we might as well reset the head/tail;
+	// with a big enough buffer this should it make it way less common
+	// that we need to wrap under normal conditions
+	if (fHead == fTail)
+		fHead = fTail = 0;
+}
+
+// see Read().
+// allows to drop the bounds checking when doing ReadChunk(), which will
+// have already tested that there's enough bytes waiting.
+uint8_t *DataRing::ReadDirect(int readLen, bool commit)
+{
+	debug("ReadDirect: request for %d bytes", readLen);
+
+	// get the number of bytes from the head to the end of buffer.
+	// this would be ((fRingSize - 1) - fHead) + 1, but we can just
+	// factor out the ones.
+	int bytesToEnd = (fRingSize - fHead);
+	uint8_t *headptr = fBuffer + fHead;
+	//trace("bytes from head to end of buffer = %d", bytesToEnd);
+
+	// move the head pointer
+	if (commit)
+		Commit(readLen);
+
+	// simple most-common case: is the requested data already contigous,
+	// as it doesn't cross the edges of the "ring"? if so, we can just give
+	// them a pointer directly to the correct offset in our buffer
+	if (readLen <= bytesToEnd) {
+		debug("common case");
+		return headptr;
+	}
+
+	// TODO: if the previous request was a peek at or a subset of this request
+	// and nothing's been added since, we could re-use the already-copied
+	// portion. this usage pattern does occur for example in PacketDecoder.
+
+	// else the requested # of bytes are "wrapped" around the end of the buffer;
+	// we'll need to reassemble it into a contiguous whole for the return.
+	debug("reassembling; piece sizes %d and %d", bytesToEnd, readLen - bytesToEnd);
+
+	// there's two ways we can assemble the requested number of bytes to a
+	// contiguous buffer: we can either copy the part at the beginning of the
+	// ring to the pad space past the end, or copy the part near the end to
+	// before the beginning. determine which one makes more sense.
+	#define preWrapCopySize	   bytesToEnd
+	int		postWrapCopySize = (readLen - bytesToEnd);
+
+	if (postWrapCopySize < preWrapCopySize)
+	{
+		#define buffer_end	(fPreBuffer + fBufTotalSize)
+		assert(fPostBuffer + (postWrapCopySize - 1) < buffer_end);
+		
+		// copy bytes from the beginning to the end, then return the head
+		memcpy(fPostBuffer, fBuffer, postWrapCopySize);
+		return headptr;
+	}
+	else
+	{
+		// copy bytes from the head to before the beginning
+		uint8_t *preCopyPtr = (fBuffer - preWrapCopySize);
+		assert(preCopyPtr >= fPreBuffer);
+	
+		memcpy(preCopyPtr, headptr, preWrapCopySize);
+		return preCopyPtr;
+	}
+
+#undef preWrapCopySize
+#undef buffer_lastbyte
+}
+
+// read [readLen] bytes and remove them from the buffer, returning a pointer
+// to them (which will be contiguous even if they were stored wrapped).
+// NOTE: you should have already checked that there are enough bytes available.
+uint8_t *DataRing::Read(int readLen, bool commit)
+{
+	assert(readLen >= 0);
+	assert(readLen <= BytesAvail());
+	return ReadDirect(readLen, commit);
+}
+
+// convenience function for reading fixed-sized structures. 
+// if there is at least [chunk_size] bytes waiting, read it and return
+// a pointer to it. else return NULL and do nothing.
+uint8_t *DataRing::ReadChunk(int chunk_size, bool commit) {
+	if (BytesAvail() >= chunk_size)
+		return ReadDirect(chunk_size, commit);
+	else
+		return NULL;
+}
+
+int DataRing::ReadByte() {
+	if (fHead == fTail)
+		return -1;
+
+	uint8_t byte = fBuffer[fHead];
+	fHead = (fHead + 1) % fRingSize;
+	return byte;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+bool DataRing::IsFull() {
+	// when full, the head pointer will be just after the tail (i.e. reversed),
+	// as the buffer will necessarily be fully wrapped in order to be full
+	//return ((fTail + 1) % fRingSize) == fHead;
+	if (fHead == 0)
+		return fTail == (fRingSize - 1);
+	else
+		return fHead == (fTail + 1);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+int DataRing::isByteInBuffer(int offs) {
+	if (offs >= fRingSize) return false;
+	if (offs < 0) return false;
+
+	//if (offs >= fHead)
+		//return 1;
+
+	if (fTail >= fHead) {
+		// "simple" case without wrap
+		return (offs >= fHead && offs < fTail) ? 1 : 0;
+	}
+	else {
+		// wrapped
+		if (offs >= fHead) return 2;
+		if (offs < fTail) return 3;
+		return 0;
+	}
+}
+
+#ifdef DATARING_DEBUG2
+void DataRing::Dump() {
+	//#define HEADCOL		"\e[1;48;2;238;36;49m"
+	//#define TAILCOL		"\e[1;48;2;80;80;238m"
+	#define HEADCOL		"\e[1;48;2;138;16;39m"
+	#define TAILCOL		"\e[1;48;2;70;70;198m"
+	#define ACTIVECOLFG	"\e[3;4m"
+	#define ACTIVECOLBG_NOWRAP	"\e[1;48;2;23;77;123m"
+	#define ACTIVECOLBG_WRAP1	"\e[1;48;2;132;58;179m"
+	#define ACTIVECOLBG_WRAP2	"\e[1;48;2;23;123;77m"
+	#define NORM		"\e[0m"
+
+	static const char *bib_to_col_map[] = {
+		NULL, ACTIVECOLBG_NOWRAP, ACTIVECOLBG_WRAP1, ACTIVECOLBG_WRAP2
+	};
+
+	DString top(stprintf("── DataRing %p ────────────────────────────", this));
+	stat("%s", top.String());
+
+	DString line;
+	line.Append(stprintf(" HheadN %d", fHead));
+	while(line.Length() < 12) line.Append(' ');
+	line.Append("TtailN ");
+	int l1len = line.Length() - 4;
+	line.Append(stprintf("%d", fTail));
+
+	#define C	22
+	while(line.Length() - 4 < C) line.Append(' ');
+
+	line.Append(stprintf("bytesInBuffer %d", BytesAvail()));
+	if (IsFull()) {
+		#define FEC			42
+		while(line.Length() - 4 < FEC) line.Append(' ');
+		line.Append("\e[1;91mFULL\e[0m");
+	}
+	
+	line.ReplaceString("H", HEADCOL);
+	line.ReplaceString("T", TAILCOL);
+	line.ReplaceString("N", NORM);
+
+	stat("%s", line.String());
+
+	line.Clear();
+	line.Append(" bufferSize");
+	int M = l1len - 1;
+	while(line.Length() < M) line.Append(' ');
+	line.Append(stprintf(" %d", fRingSize));
+	while(line.Length() < C) line.Append(' ');
+	line.Append(stprintf("bytesFree     %d", BytesFree()));
+	if (IsEmpty()) {
+		while(line.Length() < FEC) line.Append(' ');
+		line.Append("\e[1;92mEMPTY\e[0m");
+	}
+	stat("%s", line.String());
+
+	//htstack.Dump();
+
+	// ----------------
+	DString dump;
+	int linelen = 0;
+
+	#define PRINT_ADDR(A)	do { dump.Append(stprintf("%s%04x ", (A<0)?"-":" ", abs(A))); } while(0)
+	#define DUMP_BUFFER()	do {	\
+		if (linelen) {	\
+			dump.Append(line);	\
+			dump.Append('\n');	\
+		}				\
+		line.Clear();	\
+		linelen = 0;	\
+	} while(0)
+
+	line.Clear();
+
+	#define SHOW_REASSEMBLY
+	#ifdef SHOW_REASSEMBLY
+		//error("%d", fReassemblySize);exit(1);
+		uint8_t *ptr = fPreBuffer;
+		uint8_t *lastbyte = fPreBuffer + (fBufTotalSize - 1);
+	#else
+		uint8_t *ptr = fBuffer;
+		uint8_t *lastbyte = fBuffer + (fRingSize - 1);
+	#endif
+
+	int lineCounter = 0;
+	const char *color = NULL;
+	const char *nextSpace = " ";
+	while(ptr <= lastbyte)
+	{
+		bool inNormalRing = (ptr >= fBuffer && ptr < fPostBuffer);
+		int offs = (ptr - fBuffer);
+
+		if (lineCounter == 0) {
+			DUMP_BUFFER();
+			PRINT_ADDR(offs);
+		}
+		if (++lineCounter >= 16)
+			lineCounter = 0;
+	
+
+		char num[16];
+		//sprintf(num, "%02x", abs(ptr - fBuffer));
+		sprintf(num, "%02x", *ptr);
+	
+		#define GREY		"\e[1;38;2;120;40;40m"
+		if (offs == fHead) nextSpace = GREY "{" NORM;
+		line.Append((fHead == fTail) ? " " : nextSpace); nextSpace = " ";
+		if (offs == fHead) line.Append(color = HEADCOL);
+		else if (offs == fTail) line.Append(color = TAILCOL);
+
+		int inbuftype;
+		if ((inbuftype = isByteInBuffer(offs))) {
+			line.Append(ACTIVECOLFG);
+			if (!color) {
+				color = bib_to_col_map[inbuftype];
+				if (color) line.Append(color);
+			}
+		}
+
+		if (!inNormalRing)
+			line.Append(color = GREY);
+
+		line.Append(num[0]);
+		if (offs == fTail) line.Append(color = TAILCOL);
+
+		if (inNormalRing) {
+			if ((offs + 1) % fRingSize == fTail)
+				nextSpace = GREY "}" NORM;
+		}
+
+		line.Append(num[1]);
+		if (color) { color = NULL; line.Append(NORM); }
+		linelen += 3;
+
+		ptr++;
+		offs++;
+	}
+
+	if (linelen)
+		DUMP_BUFFER();
+
+	DString btm("───────────────────────────────────────────────────────");
+	stat("%s%s", dump.String(), btm.String());
+}
+#else	// !DATARING_DEBUG
+
+void DataRing::Dump() {
+	printf("DataRing: head=%d tail=%d free=%d avail=%d\n",
+			fHead, fTail, BytesFree(), BytesAvail());
+}
+
+#endif
+

--- a/src/dataring.h
+++ b/src/dataring.h
@@ -1,0 +1,139 @@
+
+#ifndef __RINPUT_DATARING_H
+#define __RINPUT_DATARING_H
+
+#include <stdlib.h>
+#include <stdint.h>
+
+// ring buffer implementation, with ability to have a "min chunk size" when
+// reading. this can also be used as a normal ring buffer by just always
+// asking to read no more than "BytesAvail()".
+//
+// this object is designed to help out once and for all with a few common
+// patterns that often can be awkward with POSIX read() operations and
+// breaking any type of "stream" data into blocks such as for packet decoding
+// on a TCP link. It implements a ring buffer of a configurable size, into
+// which you can dump arbitrary amounts of data (such as returned by a read()
+// call with a large buffer. You can then, without need to call into the
+// kernel again, perform operations such as:
+//
+//	- take data out of the buffer in particular size chunks, or only if there
+//    enough data to make an entire chunk
+//
+//	- determine very quickly how much data is in the buffer
+//
+//	- peek at data and then "put it back" if you don't want it right now
+//
+constexpr int DATARING_DEFAULT_SIZE		= 2048;
+
+class DataRing
+{
+public:
+	DataRing(int ring_initial_size = DATARING_DEFAULT_SIZE);
+	~DataRing();
+
+	void SetRingSize(int new_size);
+
+	// push/copy data into the ring. returns < 0 on error.
+	int Append(const void *data, int len);
+
+	// push data at the beginning of the ring. returns < 0 on error.
+	int Prepend(const void *data, int len);
+
+	// read a single byte from the buffer in FIFO order.
+	// returns -1 if called while the buffer is empty.
+	int ReadByte();
+
+	// read the given number of bytes and return a pointer to them,
+	// "unwrapping" the bytes if necessary (i.e. if the start and end were on
+	// opposite sides of the ring). to avoid copying, the pointer is located
+	// within the object's own ring buffer, so the data should be processed or
+	// copied before another read or insertion.
+	//
+	// if "commit" is false, then the head/tail pointers are not updated, so
+	// the data is not actually removed from the buffer. this can be used in
+	// combination with the Commit() function to implement a "peek".
+	uint8_t *Read(int len, bool commit = true);
+
+	// remove the given number of bytes from the start of the buffer,
+	// "committing" a prior "peek" (a Read() with commit=false). You must call
+	// this before doing anything else between the Read and the Commit, and
+	// the "len" parameter must be equal to what was passed to Read, or
+	// bad things will happen.
+	void Commit(int len);
+
+	// if there is at least [minSize] bytes available in the ring, read exactly
+	// that many bytes (and no more), and return a pointer to the start of it.
+	// if there is not at least chunk_size bytes yet, returns NULL.
+	uint8_t *ReadChunk(int minSize, bool commit = true);
+
+	const char *ReadLine();
+
+	int BytesAvail();		// max number of bytes you can currently read
+	int BytesFree();		// max number of bytes you can currently insert
+
+	bool IsFull();
+	inline bool IsEmpty() {
+		return (fHead == fTail);
+	}
+
+	void Dump();
+	void Clear();
+
+private:
+	uint8_t *ReadDirect(int len, bool commit);
+	int isByteInBuffer(int offs);
+
+private:
+	int fHead, fTail;
+		
+	int fRingSize;			// size of the main ring
+	int fReassemblySize;	// how much pad we have before and after the ring for doing reassembly
+	int fBufTotalSize;		// pre-buffer + ring + post-buffer = (fRingSize + (fReassemblySize * 2))
+	
+	uint8_t *fBufferBase;	// actual start of the malloc(), including any word-align padding
+	uint8_t *fBuffer;		// start of the ring (embedded between the pre and post sections)
+	uint8_t *fPreBuffer;	// actual start of the buffer for reassembly
+	uint8_t *fPostBuffer;	// pointer past end of buffer for reassembly
+
+	#ifdef CONFIG_DATARING_TESTS
+	friend void dataring_test();
+	friend bool dataring_stresstest();
+	#endif
+};
+
+// return the number of bytes currently stored in the ring buffer
+inline int DataRing::BytesAvail()
+{
+	if (fTail >= fHead)
+		return fTail - fHead;				// "normal"
+	else
+		return (fRingSize - fHead) + fTail;	// "wrapped"
+}
+
+// return the maximum number of bytes that could currently be added to the
+// buffer without overflowing
+inline int DataRing::BytesFree() {
+	return (fRingSize - BytesAvail()) - 1;
+}
+
+// simple wrapper template which saves you from needing to cast
+// (use this when storing structs/packets in the ring).
+template<class T>
+class DataRingOf : public DataRing {
+public:
+	DataRingOf(int ring_initial_size = DATARING_DEFAULT_SIZE)
+		: DataRing(ring_initial_size)
+	{ }
+
+	T *Read(int len) { return (T*)DataRing::Read(len); }
+	T *ReadChunk(int minSize, bool commit) { return (T *)DataRing::ReadChunk(minSize, commit); }
+	//T *PeekChunk(int minSize) { return (T *)DataRing::PeekChunk(minSize); }
+
+	T *ReadChunk(bool commit) {
+		return ReadChunk(sizeof(T), commit);
+	}
+};
+
+#endif
+


### PR DESCRIPTION
I used Linapple today as part of a development environment to test a little program I'm developing to upload code to my IIc through the Monitor and IN#2.

During this, I noticed that the serial-port passthrough feature does not seem to process any chars sent from the Linux host to the emulated Apple II.

This appears to be because the Super Serial Card code is only a partially-finished port of a Windows version which among other things depended on a receive thread which wasn't ever ported, thus the code to check for new chars is never called.

- This patches fixes that scenario so you can now use Linapple with  serial-port applications with functioning passthrough in both directions to a real port; very useful for testing the Linux-side of programs that will eventually be talking to their other half on a real Apple ][.

- I've also gone ahead and copied in a proper ring-buffer implementation from another of my projects and linked it up to replace the broken receive-buffer array that the comments were noting would blow up if more than one char was ever inserted, as the broken/invalid access patterns to this were driving me nutty :P. The emulator can now read() more than a single char at a time as soon as they become available to the Linux host and correctly pass the buffered chars in FIFO order as the Apple requests them.

This also patches the hardcoded serial-port device name from /dev/ttySxx to the now far-more-common /dev/ttyUSBxx. This is still kind of a hack and we should **_really_** probably update the config file parser to accept a proper device name instead of the bizarre "this number port - 1" integer setting probably inherited from Windows COM ports.

This is a one-evening fix for my other development efforts so there are probably some things that aren't perfect, but it does have the big advantage that unlike HEAD, this version of the serial-passthrough feature really works.

### Test procedure:

- Two USB-serial adapters on /dev/ttyUSB0 and /dev/ttyUSB1 were connected in a loopback configuration via a null modem.

- Configure linapple.conf to use serial port "1" (i.e. /dev/ttyUSB0 in the current weird config scheme)

- Boot Linapple to BASIC, "IN#2", then <Ctrl+A>, 14B, Enter (sets 9600 baud)

- Back on Linux host use another Terminal: picocom -b 9600 /dev/ttyUSB1

- You can now type commands into picocom and execute them on the emulated A2!

- By issuing a PR#2 now from either console you can get a cool little full-duplex A2 terminal in the Linux shell, but note that the Apple II sets the high bit of every ASCII char it transmits just like the font on the real monitor, so you will need to design/modify your terminal client to strip these.

- Note that the Apple also expects and sends a lone ASCII 13 as the carriage return sequence so you'll need to take that into account in the terminal settings. The original code didn't _quite_ set up the serial port termios correctly which caused every CR received to be translated into a LF by the kernel before making it to Linapple so you could never press Enter! A 1-line fix included in this patch corrects this, also.

- Dumb-terminal communication via emulated ProTerm also appears to work. You'll need to skip past ProTerm's modem init attempt which of course will fail in the particular setup described in this test as there's no modem (you could probably also just type back "OK" but I didn't have success with this as ProTerm's timeout seems pretty fast).