### PR TITLE
Makefile: Use `convert`, not `magick`, which broke compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.cpp | directories resources
 # Asset conversion (PNG to XPM)
 $(OBJDIR)/%.xpm: $(RESDIR)/%.png | directories
 	@echo "  XPM     $<"
-	$(Q)magick "$<" -layers flatten "$@"
+	$(Q)convert -flatten "$<" "$@"
 	$(Q)sed -i 's/static const char/static char/g' "$@"
 	$(Q)sed -i 's/$(notdir $(basename $@))\[\]/$(notdir $(basename $@))_xpm[]/g' "$@"
 


### PR DESCRIPTION
#### Commit Message

`magick` is the new command-line tool in ImageMagick 7 to replace `convert` and others. However, this breaks on currently supported systems that still provide ImageMagick 6 (e.g., Debian 12 supported until 2028 and Ubuntu 24.04 still supported until 2034).

`convert` is still present in ImageMagick 7; it's merely deprecated rather than removed. So we revert the change in b22f9fa7 and now again use `convert` instead of `magick`. This has been confirmed to build on Debian 12 (ImageMagick 6.9.11-60) and Debian 13 (ImageMagick 7.1.1-43).

When `convert` is actually removed from ImageMagick (which I anticipate will not be for years), we can evaluate whether it's worth checking to see if `magick` is available and using `convert` if not, or if at that point ImageMagick 6 is gone on supported platforms.

This also reverts the undocumented changes to the command line arguments to `magick`/`convert`; there was no explanation given for the change (or even mention of it) so I judge it best that this also goes back to what it was in case that may also cause problems on the older systems that weren't tested with this change. (If someone does want to re-introduce this, explain it and test it, than can be done in a separate change.)

#### Additional Notes

This reverts PR #210 due to the bug in it documented in issue #255. This closes issue #255.