### PR TITLE
Multi-distro Build Test

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,97 +1,113 @@
-# Installation
+Installation
+============
 
-### Prerequisites
+Prerequisites
+-------------
 
-LinApple uses **CMake** as its build system.
+LinApple uses __CMake__ as its build system.
 
-#### Debian / Ubuntu / RetroPie
+    #   Debian / Ubuntu / RetroPie
+    sudo apt update
+    sudo apt install git g++ cmake \
+        libzip-dev libcurl4-openssl-dev zlib1g-dev imagemagick
+    sudo apt install libsdl3-dev libsdl3-image-dev      # Debian 13+
 
-```bash
-sudo apt-get update
-sudo apt-get install git g++ cmake libzip-dev libsdl3-dev libsdl3-image-dev libcurl4-openssl-dev zlib1g-dev imagemagick
-```
+    #   Fedora / RHEL / CentOS
+    sudo dnf install git gcc-c++ cmake libcurl-devel libzip-devel ImageMagick
+    sudo dnf SDL3-devel SDL3_image-devel
 
-#### Fedora / RHEL / CentOS
+    #   Arch Linux
+    sudo pacman -Syu
+    sudo pacman -S base-devel cmake libcurl-gnutls zlib libzip imagemagick \
+        sdl3 sdl3_image
 
-```bash
-sudo dnf install git gcc-c++ cmake SDL3-devel SDL3_image-devel libcurl-devel libzip-devel ImageMagick
-```
+Clone the repo with:
 
-#### Arch Linux
+    git clone https://github.com/linappleii/linapple.git
+    cd linapple
 
-```bash
-sudo pacman -Syu
-sudo pacman -S base-devel cmake imagemagick libzip sdl3 sdl3_image libcurl-gnutls zlib
-```
 
-### Clone
+Configure and Compile
+---------------------
 
-```bash
-git clone https://github.com/linappleii/linapple.git
-cd linapple
-```
+    #   Create a build directory and configure with CMake (skipping tests
+    #   for a faster build). For further configuration options, see below.
+    cmake -B build -DBUILD_TESTING=OFF
 
-### Configure and Compile
+    # Compile using all available CPU cores
+    cmake --build build -j$(nproc)
 
-```bash
-# Create a build directory and configure with CMake (skipping tests for a faster build)
-cmake -B build -DBUILD_TESTING=OFF
+#### Configuration Options
 
-# Compile using all available CPU cores
-cmake --build build -j$(nproc)
-```
-
-#### Build Options
 You can pass various options to the `cmake` configuration step:
-- `-DFRONTEND=sdl3` : (Default) Build the emulator with the SDL3-based graphical frontend.
-- `-DFRONTEND=tui` : Build for the terminal using 24-bit color and Unicode characters (no GUI dependencies required).
-- `-DFRONTEND=headless` : Build the emulator without GUI or SDL dependencies (useful for automated testing or server environments).
-- `-DBUILD_TESTING=OFF` : Skip building the test suite (saves compilation time and dependency fetching).
-- `-DREGISTRY_WRITEABLE=ON` : Enable saving emulator configuration settings back to the config file.
+- `-DFRONTEND=sdl3` : (Default) Build the emulator with the SDL3-based
+  graphical frontend.
+- `-DFRONTEND=tui` : Build for the terminal using 24-bit color and Unicode
+  characters (no GUI dependencies required).
+- `-DFRONTEND=headless` : Build the emulator without GUI or SDL
+  dependencies (useful for automated testing or server environments).
+- `-DBUILD_TESTING=OFF` : Skip building the test suite (saves compilation
+  time and dependency fetching).
+- `-DREGISTRY_WRITEABLE=ON` : Enable saving emulator configuration settings
+  back to the config file.
+- `-DFRONTEND=sdl3` : (Default) Build the emulator with the SDL3-based
+  graphical frontend.
+- `-DFRONTEND=headless` : Build the emulator without GUI or SDL
+  dependencies (useful for automated testing or server environments).
+- `-DBUILD_TESTING=OFF` : Skip building the test suite (saves compilation
+  time and dependency fetching).
+- `-DREGISTRY_WRITEABLE=ON` : Enable saving emulator configuration settings
+  back to the config file.
 - `-DPROFILING=ON` : Enable `gprof` profiling output.
-- `-DCMAKE_BUILD_TYPE=Debug` : Build with debugging symbols instead of release optimizations.
+- `-DCMAKE_BUILD_TYPE=Debug` : Build with debugging symbols instead of
+  release optimizations.
 
-### Run Locally
+### Run Locally to Test
 
-After building, you can run the emulator directly from the build output directory:
+After building, you can run the emulator directly from the build output
+directory:
 
-```bash
-cd build
-./linapple
-```
+    cd build
+    ./linapple
 
-Or, to boot automatically into the standard Apple floppy disk provided with LinApple:
+    #   Or to use the standard floppy image provided with LinApple:
+    ./linapple --autoboot --d1 ../res/Master.dsk
 
-```bash
-./linapple --autoboot --d1 ../res/Master.dsk
-```
 
-### Installation
+Installation
+------------
 
 To install LinApple so it can be run from anywhere, use the `install` target.
 
-```bash
-cmake --install build
-```
+    cmake --install build
 
 #### XDG Compliance (Linux)
-The build system uses standard `GNUInstallDirs` and automatically adapts to your privileges:
-- **Non-root install (Default):** If you run `cmake --install build` as a regular user without overriding the prefix, it will install to `~/.local/bin/`, `~/.local/share/linapple/`, and `~/.config/linapple/`. This is fully compliant with XDG Base Directory specifications and does not require `sudo`.
-- **System-wide install (Root):** If you run `sudo cmake --install build`, it will install system-wide to `/usr/local/bin/`, `/usr/local/share/linapple/`, and `/usr/local/etc/linapple/`.
+
+The build system uses standard `GNUInstallDirs` and automatically adapts to
+your privileges:
+- __Non-root install (Default):__ If you run `cmake --install build` as a
+  regular user without overriding the prefix, it will install to
+  `~/.local/bin/`, `~/.local/share/linapple/`, and `~/.config/linapple/`.
+  This is fully compliant with XDG Base Directory specifications and does
+  not require `sudo`.
+- __System-wide install (Root):__ If you run `sudo cmake --install build`,
+  it will install system-wide to `/usr/local/bin/`,
+  `/usr/local/share/linapple/`, and `/usr/local/etc/linapple/`.
 
 You can also explicitly define your installation prefix during configuration:
-```bash
-cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
-sudo cmake --install build
-```
+
+    cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+    sudo cmake --install build
 
 After installation, simply run:
-```bash
-linapple
-```
+
+    linapple
 
 ### Configuration and Assets
 
-LinApple expects to find its configuration file (`linapple.conf`) in your configuration directory (e.g., `~/.config/linapple/linapple.conf`).
+LinApple expects to find its configuration file (`linapple.conf`) in your
+configuration directory (e.g., `~/.config/linapple/linapple.conf`).
 
-If the emulator cannot find a required asset (like `Master.dsk` or character fonts) in the current directory, it will automatically search the `share` and `config` directories established during installation.
+If the emulator cannot find a required asset (like `Master.dsk` or
+character fonts) in the current directory, it will automatically search the
+`share` and `config` directories established during installation.

--- a/Test
+++ b/Test
@@ -109,7 +109,7 @@ default_cont_build_specs=(
    #ubuntu-26.04-sdl3   # XXX "Compatibility with CMake < 3.5 has been removed from CMake."
     fedora-41-sdl2
    #fedora-latest-sdl3  # 44 XXX "Compatibility with CMake < 3.5 has been removed from CMake."
-   #archlinux-latest-sdl3
+   #archlinux-latest-sdl3 # XXX "Compatibility with CMake < 3.5 has been removed from CMake."
 )
 
 usage() {

--- a/Test
+++ b/Test
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+trap 'ec=$?; echo 1>&2 "INTERNAL ERROR: ec=$ec line=$LINENO cmd=$BASH_COMMAND";
+    exit $ec;' ERR
+
+####################################################################
+
+error() { echo -e 1>&2 "● ($(elapsed)s) ERROR: $(basename "$0"):" "$@"; }
+die()   { local ec=$1; shift; error "$@"; exit $ec; }
+
+elapsed_start=$(date +%s)
+elapsed() {
+    echo $(($(date +%s) - $elapsed_start))
+    #   Note that BSD/MacOS `date` doesn't support subsecond resolution.
+}
+
+#   Given $1 as a {distro}-{release}-{frontend} string,
+#   set globals $distro $release $frontend to its components,
+#   and $platform to colon-separated $distro:$release.
+#   These are implicit parameters to many routines.
+parse_build_spec() {
+    declare -g distro release frontend platform
+    local spec="$1"; shift
+    [[ $spec =~ ^([^-]+)-([^-]+)-([^-]+)$ ]] || die 2 "Bad build spec: $spec"
+      distro="${BASH_REMATCH[1]}"
+     release="${BASH_REMATCH[2]}"
+    frontend="${BASH_REMATCH[3]}"
+    platform="$distro:$release"
+}
+
+docker_unavailable() {
+    die 3 'Cannot run $docker due to setup_docker() failure (see above).'
+}
+
+setup_docker() {
+    declare -g docker docker_chown=''
+    [[ -n ${docker:-} ]] && return  # already configured from command line opt
+
+    if   podman --version >/dev/null 2>&1;  then docker=podman
+    elif docker --version >/dev/null 2>&1;  then docker=docker
+    else { docker=docker_unavailable; return 0; }
+    fi
+
+    #   On properly secured systems you must sudo to run docker (since
+    #   rootful docker implicitly gives complete root access to anybody
+    #   who can use it). Check if we connect to the server without it.
+    if ! $docker info >/dev/null 2>&1; then
+        docker="sudo $docker"
+        if ! $docker info >/dev/null 2>&1; then
+            echo 1>&2 "WARNING: Cannot 'sudo $docker info'; start proxy?"
+            docker=docker_unavailable
+        fi
+    fi
+
+    #   With rootful docker our new files in the bind mount are owned
+    #   by root outside the container, and we much chown them.
+    [[ $docker == *docker ]] \
+        && docker_chown="--chown-to $(id -u):$(id -g)"
+
+    return 0
+}
+
+####################################################################
+
+build_image() {
+    #   XXX Actually, it would be nice to use a single image for all
+    #   frontends, but we'd have to figure out how we pre-install all
+    #   the frontend deps, rather than just one.
+    declare -g build_spec force_rebuild \
+               image_name="linapple-build" \
+               image_tag="$build_spec"
+    echo "───── ($(elapsed)s) Build image $image_name:$image_tag with $docker"
+    local nocache= ; $force_rebuild && {
+        nocache=--no-cache
+        echo "• Forcing rebuild with $nocache"
+    }
+    $docker build $nocache \
+        --tag "$image_name:$image_tag" \
+        --build-arg PLATFORM="$platform" \
+        --build-arg FRONTEND="$frontend" \
+        "$PROJDIR/btools"
+}
+
+run_container() {
+    echo "───── ($(elapsed)s) Run container"
+    $docker run --rm \
+            --volume "$PROJDIR:$PROJDIR" \
+            --workdir "$PROJDIR" \
+        "$image_name:$image_tag" \
+        btools/build $docker_chown "$frontend" "$@"
+}
+
+do_build_spec() {
+    echo "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "┃   $build_spec"
+    #   parse_build_spec sets $distro $release $frontend $platform
+    parse_build_spec "$build_spec"
+    build_image
+    run_container "$@" || die 1 "FAILED: $build_spec"
+}
+
+####################################################################
+#   Usage and argparse.
+
+#   Default list if no build specs given with -s.
+default_cont_build_specs=(
+    debian-13-sdl3      debian-12-sdl2      debian-12-sdl1
+    ubuntu-24.04-sdl2   ubuntu-24.04-sdl1
+   #ubuntu-26.04-sdl3   # XXX "Compatibility with CMake < 3.5 has been removed from CMake."
+    fedora-41-sdl2
+   #fedora-latest-sdl3  # 44 XXX "Compatibility with CMake < 3.5 has been removed from CMake."
+   #archlinux-latest-sdl3
+)
+
+usage() {
+    cat <<_____
+Usage: $(basename "$0") [-s BUILD_SPEC]… --local|--container [BUILD-ARGS]
+
+Do a local (i.e., curent host) build or container build(s) for Linux build
+specifications '{distro}-{release}-{frontend}', e.g. 'ubuntu-24.04-sdl2'.
+One or more -s options build specific specs; no -s options use the default
+build spec(s): --local '$( $(dirname "$0")/btools/prereq-inst --spec )', and --container:
+  ${default_cont_build_specs[@]}
+
+* 'btools/build BUILD-ARGS' does the actual build.
+* The output (whether local or via container) is placed under
+  'build/{distro}-{release}-{frontend}/'.
+* For more information, see INSTALL.md, and run
+  'btools/prereq-inst --help' and 'btools/build --help'.
+_____
+    exit 0
+}
+
+build_type=
+build_specs=()
+force_rebuild=false
+while [[ $# -gt 0 ]]; do case "$1" in
+    -h|--help)          usage;;
+    --local|--lo*)      shift; build_type=local;;
+    --container|--co*)  shift; build_type=container;;
+    -s|--spec)          shift; build_specs+=($1); shift;;
+    -f|--force-rebuild) shift; force_rebuild=true;;
+    -p)                 shift; docker="$1"; shift;;
+    -*)                 die 2 "Unknown option: '$1'; --help for help";;
+    --)                 break;;
+    *)                  break;;
+esac; done
+
+####################################################################
+#   Main
+
+PROJDIR=$(command cd $(dirname "$0") && pwd -P)
+case $build_type in
+
+    local)
+        #   Build on 'local' system, without containers.
+        if [[ ${#build_specs[@]} -eq 0 ]]; then
+            #   Current platform, default frontend.
+            "$PROJDIR/btools/prereq-inst"
+            "$PROJDIR/btools/build" "$@"
+        else
+            #   Platform(s) and frontend(s) specified.
+            #   The user is expected to provide specs compatible with the
+            #   local system (typically {distro}-{release} of exactly the
+            #   local system, plus an appropriate -{frontend}).
+            for build_spec in ${build_specs[@]}; do
+                echo "━━━━━ $build_spec"
+                distro=${build_spec%-*}     # strip shortest trailing -*
+                frontend=${build_spec##*-}  # strip longest leading  *-
+                D="${distro:+-D}"; Darg="${distro//-/:}"
+                echo "• distro='$distro' frontend='$frontend'"
+                "$PROJDIR/btools/prereq-inst" $D $Darg "$frontend"
+                "$PROJDIR/btools/build"       $D $Darg "$frontend" "$@"
+            done
+        fi
+        ;;
+
+    container)
+        setup_docker
+        [[ ${#build_specs[@]} -eq 0 ]] && build_specs=("${default_cont_build_specs[@]}")
+        echo '▶ Build specs:' "${build_specs[@]}"
+        mkdir -p "$PROJDIR/build/Testlog"
+        for build_spec in "${build_specs[@]}"; do
+            #   Ensure we can write the log before we start generating it.
+            > "$PROJDIR/build/Testlog/$build_spec"
+            do_build_spec 2>&1 | tee "$PROJDIR/build/Testlog/$build_spec"
+        done
+        ;;
+
+    *)
+        die 2 "Must specify --local or --container; see --help"
+        ;;
+
+esac
+echo "━━━━━ ($(elapsed)s) OK"
+
+#   XXX -d DISTRO -f FRONTEND   (either implies --current?)
+#               no, maybe better limits --all? patterns? `-d deb` for deb*?

--- a/btools/Dockerfile
+++ b/btools/Dockerfile
@@ -1,0 +1,6 @@
+# check=skip=InvalidDefaultArgInFrom   $PLATFORM unset produces good error
+ARG PLATFORM
+FROM ${PLATFORM}
+ARG FRONTEND PLATFORM
+COPY common.bash prereq-inst /tmp/
+RUN /tmp/prereq-inst ${FRONTEND} && rm /tmp/common.bash /tmp/prereq-inst

--- a/btools/README.md
+++ b/btools/README.md
@@ -1,0 +1,10 @@
+linapple btools
+===============
+
+This directory contains build tools for linapple.
+
+- `Dockerfile`: Template to create Podman or Docker images used to build
+  and test linapple on various Linux distributions.
+- `functions.bash`: Functions shared by install and build scripts.
+- `prereq-inst`: Installs build pre-requisites. Use `--help` for more info.
+- `build`: Builds linapple and runs the tests. Use `--help` for more info.

--- a/btools/build
+++ b/btools/build
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+#   btools/build - Build linapple for a distro/frontend
+#
+#   See usage() for details.
+#
+
+chown_builddir() {          # Used by --chown-to.
+    local to="$1"; shift
+    #   In case we created the parent of $BUILDDIR_REL.
+    chown "$to" "$(dirname "$PROJDIR/$BUILDDIR_REL")" || true
+    chown -R "$to" "$PROJDIR/$BUILDDIR_REL" \
+        || echo 1>&2 "WARNING: chown -R '$to' '$BUILDDIR_REL' failed"
+}
+
+####################################################################
+#   Usage and argument parsing.
+
+usage() {
+    cat <<_____
+Usage: $(basename "$0") [OPTS] [-D DISTRO] [FRONTEND]
+For the current distro  and given (or default) frontend, builds linapple
+and runs tests. Assumes all prerequisites are intalled (see 'prereq-inst').
+The build is placed in build/{distro}-{release}-{frontend}/.
+
+Options:
+  -h,--help         Print this message.
+  --chown OWNER     On exit, chown -R the build dir to OWNER (UID:GID or
+                    user:group); failures warn but do not abort. You want
+                    this for rootful container builds writing to a bind-
+                    mounted host dir.
+  -D ID:VERSION_ID  Use given distro information instead of autodetecting
+                    from /etc/os-release. E.g. 'ubuntu:24.04'.
+                    You should never need this.
+_____
+    usage_frontends
+    exit 0
+}
+
+source $(dirname "$0")/common.bash
+
+chown_to=
+force_distro=
+FRONTEND=
+while [[ $# -gt 0 ]]; do case "$1" in
+    -h|--help)      usage;;
+    -D)             shift; force_distro="$1"; shift;;
+    --chown-to)     shift; chown_to="$1"; shift;;
+    -*)             die 2 "Unknown option: '$1'; see --help.";;
+    --)             shift; break;;
+    *)              break;;
+esac; done
+[[ $# -gt 0 ]] && { FRONTEND="$1"; shift; }
+[[ $# -eq 0 ]] || die 2 "Too many arguments; see --help."
+
+set_distro
+check_frontend
+
+####################################################################
+
+#   No colon in builddir path because even on Linux it makes Cmake upset.
+#   This is relative because we need to `cd` to `cmake` anyway, so why
+#   not keep it short for messages etc.
+echo "▶ DISTRO=$ID:$VERSION_ID FRONTEND=$FRONTEND"
+
+command cd "$PROJDIR"
+echo '━━━━━ Cmake setup'
+BUILDDIR_REL="build/$ID-$VERSION_ID-$FRONTEND"
+echo "▶ BUILDDIR=$BUILDDIR_REL"
+[[ -n $chown_to ]] && trap "chown_builddir $chown_to" EXIT
+cmake -B "$BUILDDIR_REL" -DFRONTEND=$FRONTEND
+echo '━━━━━ Cmake build'
+echo ● cmake --quiet --build "$BUILDDIR_REL" -j$(nproc)
+cmake --build "$BUILDDIR_REL" -j$(nproc)
+echo '━━━━━ Unit Tests'
+( cd "$BUILDDIR_REL" \
+  && SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy
+     ctest --output-on-failure
+) || true

--- a/btools/common.bash
+++ b/btools/common.bash
@@ -61,6 +61,7 @@ default_frontend() {
         #   SDL3 became available in Fedora 40, got stable in 41, and
         #   in 42 SDL2 was removed.
         fedora)     [[ $rel -ge 42 ]]       && echo sdl3 || echo sdl2;;
+        arch)                                  echo sdl3             ;;
         *)          die 4 "No default frontends known for distro $ID";;
     esac
 }

--- a/btools/common.bash
+++ b/btools/common.bash
@@ -1,0 +1,89 @@
+#   common.bash - common code used by other scripts in this directory
+#
+#   This is expected to be `source`d.
+
+#####################################################################
+#   Common setup
+
+set -Eeuo pipefail
+trap 'ec=$?; echo 1>&2 "INTERNAL ERROR: ec=$ec line=$LINENO cmd=$BASH_COMMAND";
+    exit $ec;' ERR
+
+export PROJDIR=$(command cd $(dirname "$0")/.. && pwd -P)
+
+#####################################################################
+#   Utility functions
+
+error() { echo -e 1>&2 "● ERROR: $(basename "$0"):" "$@"; }
+die()   { local ec=$1; shift; error "$@"; exit $ec; }
+
+#####################################################################
+#   Linux distribution/release handling
+
+#   Set variables defined in /etc/os-release, in particular $ID and
+#   $VERSION_ID. If /etc/os-release doesn't exist these may be synthesised
+#   through other means, otherwise this exits with an error.
+os_release() {
+    [[ -r /etc/os-release ]] \
+        || die 1 "/etc/os-release not found; cannot autodetect distro"
+    source /etc/os-release
+    [[ -n ${ID:-} && -n ${VERSION_ID:-} ]] \
+        || die 5 '$ID and/or $VERSION_ID not set in /etc/os-release'
+}
+
+set_distro() {
+    declare -g force_distro     # set by a -D option, if desired
+    declare -g ID VERSION_ID
+
+    if [[ -z $force_distro ]]; then
+        os_release
+    else
+        if [[ $force_distro =~ ^([^:]+):([^:]+)$ ]]; then
+            ID=${BASH_REMATCH[1]}
+            VERSION_ID=${BASH_REMATCH[2]}
+        else
+            die 2 "DISTRO must be 'name:ver'"
+        fi
+    fi
+}
+
+#####################################################################
+#   Frontend handling
+
+#   We have ID and VERSION_ID but FRONTEND has not been specified. Choose
+#   an appropriate default for FRONTEND or exit with an error indicating we
+#   have no default.
+default_frontend() {
+    local rel=$VERSION_ID
+    case $ID in
+        debian)     [[ $rel -ge 13 ]]       && echo sdl3 || echo sdl2;;
+        ubuntu)     [[ $rel  >  24.04 ]]    && echo sdl3 || echo sdl2;;
+        #   SDL3 became available in Fedora 40, got stable in 41, and
+        #   in 42 SDL2 was removed.
+        fedora)     [[ $rel -ge 42 ]]       && echo sdl3 || echo sdl2;;
+        *)          die 4 "No default frontends known for distro $ID";;
+    esac
+}
+
+check_frontend() {
+    declare -g FRONTEND
+
+    [[ -n $FRONTEND ]] || FRONTEND=$(default_frontend)
+
+    #   Ensure $FRONTEND is known value. There are unfortunately no checks
+    #   to see that the rest of the code supports all of these, or that
+    #   usage() correctly reflects these.
+    case $FRONTEND in
+        sdl[123])   return 0;;
+        *)          die 2 "Unknown frontend: '$FRONTEND'. See --help.";;
+    esac
+}
+
+usage_frontends() {
+    cat <<_____
+Known frontends:
+  sdl3  Simple DirectMedia Layer, version 3
+  sdl2  Simple DirectMedia Layer, version 2
+  sdl1  Simple DirectMedia Layer, version 1
+_____
+}

--- a/btools/prereq-inst
+++ b/btools/prereq-inst
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+#   prereq-inst - Install linapple build prerequisites for a distro/frontend
+#
+#   See usage() for details.
+#
+set -Eeuo pipefail
+trap 'ec=$?; echo 1>&2 "INTERNAL ERROR: ec=$ec line=$LINENO cmd=$BASH_COMMAND";
+    exit $ec;' ERR
+
+error() { echo -e 1>&2 "● ERROR: $(basename "$0"):" "$@"; }
+die()   { local ec=$1; shift; error "$@"; exit $ec; }
+
+#   $1 is a timestamp dir or file.
+#   If modified within the last hour, return 1, otherwise 0.
+#   This never touches the file; use set_update() to do that.
+needs_update() {
+    local timestamp="$1"; shift
+    [[ -e $timestamp ]] || return 0
+    local age=$(( $(date +%s) - $(stat -c %Y "$timestamp") ))
+    (( age <= ${1:-7200} )) || return 0
+    return 1
+}
+set_update() {
+    local timestamp="$1"; shift
+    touch "$timestamp"
+}
+
+sudo=
+set_sudo() {
+    declare -g sudo
+    [[ $(id -u) -eq 0 ]] || sudo=sudo
+}
+
+####################################################################
+
+install_prerequisites() {
+    echo '━━━━━ Install prerequisites'
+
+    #   This needs to be on a filesystem local to the container, if we're using
+    #   one, so that we don't honour a stale timestamp in a new container.
+    local tsfile="/tmp/linappleii-linapple/prereq-$ID-$VERSION_ID-$FRONTEND"
+    mkdir -p "$(dirname "$tsfile")"
+    #   Skip if not forced and we updated/installed in the last hour.
+    { $force_install || needs_update "$tsfile"; } \
+        || { echo 'updated recently; skipping'; return 0; }
+
+    local known_ids=(       # all these must be in the `case` below.
+        debian ubuntu fedora
+    )
+    local id k
+    for distro in "$ID" ${ID_LIKE:-}; do        # split $ID_LIKE
+        for k in "${known_ids[@]}"; do
+            #   Stop both loops at first one we know.
+            [[ $distro == "$k" ]] && break 2
+        done
+        die 4 "This system's IDs match no known distros" \
+            "\n• Known:" "${known_ids[@]}" \
+            "\n• ID=$ID ID_LIKE=${ID_LIKE:-}"
+    done
+
+    case "$distro" in
+        debian|ubuntu)  install_deps_debian;;
+        fedora)         install_deps_fedora;;
+                        #   $ID_LIKE grabs RHEL/CentOS/Rocky/Alma, too.
+        *)              die 10 "Internal error: set unknown distro '$distro'";;
+    esac
+    set_update "$tsfile"
+}
+
+#   For these distro-specific functions, you can compare/check against what
+#   .github/workflows/build.yaml installs.
+
+install_deps_debian() {
+    echo '───── apt update'
+    $sudo apt update && $sudo touch /var/lib/apt/lists
+    echo '───── apt dist-upgrade'
+    $sudo apt dist-upgrade -y
+    echo '───── apt install'
+    $sudo apt install -y -q \
+        git g++ cmake \
+        libzip-dev libcurl4-openssl-dev zlib1g-dev imagemagick
+    case "$FRONTEND" in
+        sdl1)   $sudo apt install -y -q libsdl1.2-dev libsdl-image1.2-dev;;
+        sdl2)   $sudo apt install -y -q libsdl2-dev libsdl2-image-dev;;
+        sdl3)   $sudo apt install -y -q libsdl3-dev libsdl3-image-dev;;
+        *)      die 4 "Unknown frontend: $FRONTEND";;
+    esac
+}
+
+install_deps_fedora() {
+    #   No apt-lists timestamp to refresh: dnf manages metadata expiry
+    #   itself, and --refresh forces it the way `apt update` does.
+    echo '───── dnf upgrade'
+    $sudo dnf upgrade -y --refresh
+    echo '───── dnf install'
+    $sudo dnf install -y \
+        git gcc-c++ cmake \
+        libzip-devel libcurl-devel zlib-devel ImageMagick
+    case "$FRONTEND" in
+        sdl1)   $sudo dnf install -y  SDL-devel  SDL_image-devel;;
+        sdl2)   $sudo dnf install -y SDL2-devel SDL2_image-devel;;
+        sdl3)   $sudo dnf install -y SDL3-devel SDL3_image-devel;;
+        *)      die 4 "Unknown frontend: $FRONTEND";;
+    esac
+}
+
+####################################################################
+#   Usage, argument parsing, main.
+
+usage() {
+    cat <<_____
+Usage: $(basename "$0") [OPTS] [-D DISTRO] [FRONTEND]
+  Install the linapple build prerequisites for the current distro and given
+  frontend, or the default frontend if not specified.
+Options:
+  -h,--help         Print this message.
+  -s,--spec         Print build spec instead of installing.
+  -f                Force package update and install, even if it's already
+                    been done in the last hour.
+  -D ID:VERSION_ID  Use given distro information instead of autodetecting
+                    from /etc/os-release. E.g. 'ubuntu:24.04'.
+                    You should never need this.
+_____
+    usage_frontends
+    exit 0
+}
+
+source $(dirname "$0")/common.bash
+
+force_distro=
+force_install=false
+print_build_spec=false
+FRONTEND=
+while [[ $# -gt 0 ]]; do case "$1" in
+    -h|--help)      usage;;
+    -D)             shift; force_distro="$1"; shift;;
+    -f)             shift; force_install=true;;
+    -s|--spec)      shift; print_build_spec=true;;
+    --)             shift; break;;
+    -*)             die 2 "Unknown option: '$1'; try --help.";;
+    *)              break;;
+esac; done
+[[ $# -gt 0 ]] && { FRONTEND="$1"; shift; }
+[[ $# -eq 0 ]] || die 2 "Too many arguments; see --help."
+
+set_distro
+check_frontend
+$print_build_spec &&  {
+    echo "$ID-$VERSION_ID-$FRONTEND"
+    exit 0
+}
+echo "▶ DISTRO=$ID:$VERSION_ID FRONTEND=$FRONTEND"
+set_sudo
+install_prerequisites

--- a/btools/prereq-inst
+++ b/btools/prereq-inst
@@ -46,7 +46,7 @@ install_prerequisites() {
         || { echo 'updated recently; skipping'; return 0; }
 
     local known_ids=(       # all these must be in the `case` below.
-        debian ubuntu fedora
+        debian ubuntu fedora arch
     )
     local id k
     for distro in "$ID" ${ID_LIKE:-}; do        # split $ID_LIKE
@@ -63,6 +63,7 @@ install_prerequisites() {
         debian|ubuntu)  install_deps_debian;;
         fedora)         install_deps_fedora;;
                         #   $ID_LIKE grabs RHEL/CentOS/Rocky/Alma, too.
+        arch)           install_deps_arch;;
         *)              die 10 "Internal error: set unknown distro '$distro'";;
     esac
     set_update "$tsfile"
@@ -103,6 +104,14 @@ install_deps_fedora() {
         sdl3)   $sudo dnf install -y SDL3-devel SDL3_image-devel;;
         *)      die 4 "Unknown frontend: $FRONTEND";;
     esac
+}
+
+install_deps_arch() {
+    #   Only the SDL3 frontend is supported on arch, at least for the moment.
+    $sudo pacman -Syu --noconfirm
+    $sudo pacman -S --noconfirm \
+        git base-devel cmake imagemagick libzip libcurl-gnutls zlib \
+        sdl3 sdl3_image
 }
 
 ####################################################################


### PR DESCRIPTION
This isn't ready to go in yet, but it does offer a rough idea of where I'm going. Basically:
* Tentatively, new `btools/` subdir for build tools.
* All builds figure out your distro and install the dependencies you need. (Or tell you you're weird, in which case you need to figure out yourself what packages you need. INSTALL.md will be updated to provide assistance with this.)
* `./Test --current` builds on the platform you're using right now (into `build/{distro}-{release}-{frontend}`), giving you a binary you can just run.
* `./Test` does various builds (`debian-13-sdl3 debian-12-sdl2 debian-12-sdl1.2` right now, but more will be added) using Docker containers, but with bind mounts so the output is all left under `build/` as above.
* We need to add the unit tests etc. to this, too.

Where this is getting us is that you can test across lots of different platforms and frontends fairly quickly with one command. The first run can take quite some time, due to building containers that have the dependencies installed, but a no-change re-run for all three builds-above is about 8 seconds on my desktop MiniPC (though one build is still broken). That's not to say that there isn't a lot more I could do to have better caching on the image and container builds.

Note that this can all run fine as a GitHub workflow, too, if the host running it is configured properly. But you don't need to push and wait for the workflow; you can just run this locally in exactly the same way the workflow would run it.